### PR TITLE
Removed `jupyter` and `ipywidgets` from Dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eurybia"
-version = "1.3.1"
+version = "1.3.2"
 authors = [
     {name = "Nicolas Roux"},
     {name = "Thomas Bouché", email = "thomas.bouche@maif.fr"},
@@ -27,12 +27,10 @@ dependencies = [
     "pandas>=2",
     "catboost>=1.0.1",
     "panel>=1.4.1",
-    "ipywidgets>=7.4.2",
     "jinja2>=2.11.0",
     "scipy>=1.4.0",
     "seaborn>=0.10.1",
     "shapash>=2.0.0",
-    "jupyter",
     "plotly",
 ]
 


### PR DESCRIPTION
Fixes: #67 

#### Description
This PR removes unnecessary dependencies, namely `jupyter` and `ipywidgets`, from the `pyproject.toml` file. These dependencies were not required for core functionality and could lead to unnecessary bloat in environments where these tools are not needed.

#### Key Changes:
- **Removed Unnecessary Dependencies**:
  - The following packages were removed from the `dependencies` section in `pyproject.toml`:
  
```toml
dependencies = [
                "pandas>=2",
                "catboost>=1.0.1",
                "panel>=1.4.1",
                "jinja2>=2.11.0",
                "scipy>=1.4.0",
                "seaborn>=0.10.1",
                "shapash>=2.0.0",
                "plotly",
                # Removed unnecessary dependencies
                # "jupyter",
                # "ipywidgets",
             ]
```

#### Benefits:
- **Reduced Environment Size**: By removing these unnecessary packages, the overall environment becomes lighter and faster to install.
- **Improved Setup Time**: With fewer dependencies to install, the setup process will be faster, particularly for CI pipelines and production environments.
- **Increased Flexibility**: The project becomes more portable and flexible, as it does not impose notebook-related dependencies on all environments.
