### PR TITLE
Restore Missing Colors in colors.json for Shapash 2.7.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eurybia"
-version = "1.3.2"
+version = "1.3.3"
 authors = [
     {name = "Nicolas Roux"},
     {name = "Thomas Bouché", email = "thomas.bouche@maif.fr"},


### PR DESCRIPTION
Fixes: #72 

**Description**:  
This PR addresses an issue where several colors are missing in the `colors.json` file following the release of Shapash version 2.7.*. The absence of these colors has resulted in failures when generating certain graphs in the reports created by Eurybia.

This PR aims to restore functionality by ensuring the `colors.json` file contains all necessary color definitions.
