### PR TITLE
Feature/refacto dataset

### DIFF
--- a/eurybia/core/dataset_analysis.py
+++ b/eurybia/core/dataset_analysis.py
@@ -206,20 +206,20 @@ class DatasetAnalysis:
 
         Returns:
             dict: A dictionary where keys are column names with differing float precisions, and values are tuples
-                  of (test dataset max precision, baseline dataset max precision).
+                  of (test dataset max precision, baseline dataset max precision) as integers.
         """
 
         def nb_digits(i: float):
             split_i = str(i).split(".")
             return len(split_i[1]) if len(split_i) > 1 else 0
 
-        different_float_precision: dict[str, tuple[str, str]] = dict()
+        different_float_precision: dict[str, tuple[int, int]] = dict()
 
         for colname in self.float_cols:
             baseline_digits = self._df_baseline[colname].apply(nb_digits)
             test_digits = self._df_test[colname].apply(nb_digits)
-            baseline_max_precision = np.max(baseline_digits)
-            test_max_precision = np.max(test_digits)
+            baseline_max_precision = int(np.max(baseline_digits))
+            test_max_precision = int(np.max(test_digits))
             if baseline_max_precision != test_max_precision:
                 different_float_precision[colname] = (test_max_precision, baseline_max_precision)
 

--- a/eurybia/core/dataset_analysis.py
+++ b/eurybia/core/dataset_analysis.py
@@ -123,7 +123,7 @@ class DatasetAnalysis:
         Returns:
             dict[str, tuple[str, str]]:
                 A dictionary where each key is a column name with a data type mismatch,
-                and the value is a tuple containing the data types from the baseline and test DataFrames, respectively.
+                and the value is a tuple containing the data types from the test and baseline DataFrames, respectively.
         """
         dtype_mismatches: dict[str, tuple[str, str]] = dict()
         for colname in self.intersecting_columns:

--- a/eurybia/core/dataset_analysis.py
+++ b/eurybia/core/dataset_analysis.py
@@ -238,8 +238,8 @@ class DatasetAnalysis:
                 A tuple containing the cleaned test and baseline DataFrames.
         """
 
-        df_test = self._df_test
-        df_baseline = self._df_baseline
+        df_test = self._df_test.copy()
+        df_baseline = self._df_baseline.copy()
 
         # keep only columns of same name and type
         df_test = self._fix_valid_cols(df_test)

--- a/eurybia/core/dataset_analysis.py
+++ b/eurybia/core/dataset_analysis.py
@@ -38,8 +38,9 @@ class DatasetAnalysis:
         self,
         df_test: pd.DataFrame,
         df_baseline: pd.DataFrame,
-        sample_size: int | None = None,
         ignored_cols: list[str] | None = None,
+        sample_size: int | None = None,
+        random_state: int = 42,
     ):
         """
         Initializes the dataset analysis object with test and baseline DataFrames,
@@ -48,8 +49,9 @@ class DatasetAnalysis:
         Args:
             df_test (pd.DataFrame): The test dataset to analyze.
             df_baseline (pd.DataFrame): The baseline dataset for comparison.
-            sample_size (int | None, optional): If provided, limits both datasets to this number of samples.
             ignored_cols (list[str] | None, optional): List of column names to ignore in both datasets.
+            sample_size (int | None, optional): If provided, limits both datasets to this number of samples.
+            random_state (int, optional): Random seed used when sampling rows from the datasets.
         """
         self._ignored_cols: list[str] = ignored_cols if ignored_cols is not None else []
         self._df_test = df_test.drop(self._ignored_cols, axis=1, errors="ignore")
@@ -57,9 +59,9 @@ class DatasetAnalysis:
 
         if sample_size is not None:
             if self._df_test.shape[0] > sample_size:
-                self._df_test = self._df_test.sample(sample_size)
+                self._df_test = self._df_test.sample(sample_size, random_state=random_state)
             if self._df_baseline.shape[0] > sample_size:
-                self._df_baseline = self._df_baseline.sample(sample_size)
+                self._df_baseline = self._df_baseline.sample(sample_size, random_state=random_state)
 
     @property
     def ignored_cols(self) -> list[str]:

--- a/eurybia/core/dataset_analysis.py
+++ b/eurybia/core/dataset_analysis.py
@@ -1,0 +1,367 @@
+"""dataset_analysis module"""
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype, is_float_dtype, is_integer_dtype, is_object_dtype
+from sklearn.model_selection import train_test_split
+
+MANDATORY_FIXES = ["same_cols", "str_fillna", "numeric_fillna", "date_split"]
+DEFAULT_OPTIONAL_FIXES = ["float_precision", "float_to_int"]
+
+
+class DatasetAnalysis:
+    """_summary_"""
+
+    def __init__(
+        self,
+        df_test: pd.DataFrame,
+        df_baseline: pd.DataFrame,
+        sample_size: int | None = None,
+        ignored_cols: list[str] | None = None,
+        optional_fixes: list[str] | None = None,
+    ):
+        """
+        Initializes the DatasetAnalysis class.
+
+        Args:
+            df_baseline (pd.DataFrame): The baseline DataFrame.
+            df_test (pd.DataFrame): The test DataFrame to compare against the baseline.
+            ignore_cols (list[str] | None): List of column names to ignore during analysis. Defaults to None.
+        """
+        self._ignored_cols: list[str] = ignored_cols if ignored_cols is not None else []
+        self._df_test = df_test.drop(self._ignored_cols, axis=1, errors="ignore")
+        self._df_baseline = df_baseline.drop(self._ignored_cols, axis=1, errors="ignore")
+
+        if sample_size is not None:
+            if self._df_test.shape[0] > sample_size:
+                self._df_test = self._df_test.sample(sample_size)
+            if self._df_baseline.shape[0] > sample_size:
+                self._df_baseline = self._df_baseline.sample(sample_size)
+
+        self._fixes = MANDATORY_FIXES
+        if optional_fixes is None:
+            optional_fixes = DEFAULT_OPTIONAL_FIXES
+        self._fixes += optional_fixes
+
+        self._fixes_state = {fix: False for fix in self._fixes}
+        self._df_concat: pd.DataFrame = None
+
+    @property
+    def df_baseline(self) -> pd.DataFrame:
+        """Getter"""
+        return self._df_baseline
+
+    @df_baseline.setter
+    def df_baseline(self, val) -> None:
+        self._df_baseline = val
+
+    @property
+    def df_test(self) -> pd.DataFrame:
+        """Getter"""
+        return self._df_test
+
+    @df_test.setter
+    def df_test(self, val) -> None:
+        self._df_test = val
+
+    @property
+    def df_concat(self) -> pd.DataFrame:
+        """Concatenates the baseline and test DataFrames and returns a single DataFrame.
+
+        Returns:
+            pd.DataFrame: A DataFrame resulting from concatenating `self.df_baseline` and `self.df_test`,
+            with the index reset.
+        """
+        if self._df_concat is None:
+            train, test = self.train_test_split(test_size=0.25, random_state=42)
+            self._df_concat = pd.concat([train, test]).reset_index(drop=True)
+        return self._df_concat
+
+    @property
+    def ignored_cols(self) -> list[str]:
+        """Getter"""
+        return self._ignored_cols
+
+    @property
+    def fixes_state(self) -> dict:
+        """Getter"""
+        return self._fixes_state
+
+    def _set_fix_applied(self, fix) -> None:
+        if fix not in self._fixes_state.keys():
+            raise RuntimeError("")
+        self._fixes_state[fix] = True
+
+    @property
+    def valid_columns(self) -> list[str]:
+        """Returns the list of intersecting column names that have the same data type across datasets.
+
+        Returns:
+            list[str]: A list of valid column names with consistent data types.
+        """
+
+        return [c for c in self.intersecting_columns if self._has_same_dtype(c)]
+
+    @property
+    def intersecting_columns(self) -> list[str]:
+        """Returns a list of column names that are present in both df_test and df_baseline.
+
+        Returns:
+            list[str]: List of column names common to both df_test and df_baseline.
+        """
+        return [c for c in self.df_test.columns if c in self.df_baseline.columns]
+
+    @property
+    def new_columns(self) -> list[str]:
+        """Identifies columns that have been added by comparing df_test and df_baseline.
+
+        Returns:
+            list[str]: A list of column names that exist in df_test but not in df_baseline.
+        """
+        return [c for c in self.df_test.columns if c not in self.df_baseline.columns]
+
+    @property
+    def removed_columns(self) -> list[str]:
+        """Identifies columns that have been removed by comparing df_baseline and df_test.
+
+        Returns:
+            list[str]: A list of column names that exist in df_baseline but not in df_test.
+        """
+        return [c for c in self.df_baseline.columns if c not in self.df_test.columns]
+
+    def _has_same_dtype(self, colname: str) -> bool:
+        """Check if the specified column has the same data type in both the baseline and test DataFrames.
+
+        Args:
+            colname (str): The name of the column to compare.
+        Returns:
+            bool: True if the column has the same data type in both DataFrames, False otherwise.
+        """
+
+        return self.df_baseline[colname].dtype == self.df_test[colname].dtype
+
+    @property
+    def dtype_mismatches(self) -> dict[str, tuple[str, str]]:
+        """Identifies columns with mismatched data types between the baseline and test DataFrames.
+
+        Returns:
+            dict[str, tuple[str, str]]:
+                A dictionary where each key is a column name with a data type mismatch,
+                and the value is a tuple containing the data types from the baseline and test DataFrames, respectively.
+        """
+        dtype_mismatches: dict[str, tuple[str, str]] = dict()
+        for colname in self.intersecting_columns:
+            if not self._has_same_dtype(colname):
+                dtype_mismatches[colname] = (
+                    str(self.df_test[colname].dtype),
+                    str(self.df_baseline[colname].dtype),
+                )
+        return dtype_mismatches
+
+    @property
+    def object_cols(self) -> list[str]:
+        """Returns a list of column names from the intersecting and not dtype mismatching columns
+        whose data type is string.
+
+        Returns:
+            list[str]: List of column names with 'object' dtype and no dtype mismatches.
+        """
+
+        return [colname for colname in self.valid_columns if is_object_dtype(self.df_baseline[colname].dtype)]
+
+    @property
+    def float_cols(self) -> list[str]:
+        """Returns a list of column names from the intersecting and not dtype mismatching columns
+        whose data type is float.
+
+        Returns:
+            list[str]: List of column names with 'float' dtype and no dtype mismatches.
+        """
+
+        return [colname for colname in self.valid_columns if is_float_dtype(self.df_baseline[colname])]
+
+    @property
+    def datetime_cols(self) -> list[str]:
+        """Returns a list of column names from the intersecting and not dtype mismatching columns
+        whose data type is datetime.
+
+        Returns:
+            list[str]: List of column names with datetime dtype and no dtype mismatches.
+        """
+        return [colname for colname in self.valid_columns if is_datetime64_any_dtype(self.df_baseline[colname])]
+
+    @property
+    def categorical_value_differences(self):
+        """Identifies and returns the differences in categorical (object) column values
+        between the baseline and test datasets.
+
+        For each object column, the method compares the unique values (modalities)
+        present in the baseline and test datasets.
+        It records any new values found in the test dataset that are not in the baseline,
+        as well as any missing values that are present in the baseline but absent in the test dataset.
+
+        Returns:
+            dict: A dictionary where each key is an object column name, and the value is another dictionary with:
+                - "New values": List of values present in the test dataset but not in the baseline.
+                - "Missing values": List of values present in the baseline but not in the test dataset.
+        """
+        different_modalities: dict[str, dict[str, list[str]]] = dict()
+        for colname in self.object_cols:
+            baseline_modalities = pd.unique(self.df_baseline[colname])
+            test_modalities = pd.unique(self.df_test[colname])
+
+            new_modalities = [mod for mod in test_modalities if mod not in baseline_modalities]
+            missing_modalities = [mod for mod in baseline_modalities if mod not in test_modalities]
+
+            if (len(new_modalities) > 0) or (len(missing_modalities) > 0):
+                different_modalities[colname] = {
+                    "New values": new_modalities,
+                    "Missing values": missing_modalities,
+                }
+        return different_modalities
+
+    @property
+    def float_precision_differences(self):
+        """Analyzes the precision (number of digits after the decimal point) of float columns
+        in the baseline and test datasets.
+
+        For each float column, calculates the maximum number of decimal digits present
+        in both the baseline and test datasets. If the maximum precision differs between the two datasets
+        for any column, records the column name and the respective precisions.
+
+        Returns:
+            dict: A dictionary where keys are column names with differing float precisions, and values are tuples
+                  of (test dataset max precision, baseline dataset max precision).
+        """
+
+        def nb_digits(i: float):
+            split_i = str(i).split(".")
+            return len(split_i[1]) if len(split_i) > 1 else 0
+
+        different_float_precision: dict[str, tuple[str, str]] = dict()
+
+        for colname in self.float_cols:
+            baseline_digits = self.df_baseline[colname].apply(nb_digits)
+            test_digits = self.df_test[colname].apply(nb_digits)
+            baseline_max_precision = np.max(baseline_digits)
+            test_max_precision = np.max(test_digits)
+            if baseline_max_precision != test_max_precision:
+                different_float_precision[colname] = (test_max_precision, baseline_max_precision)
+
+        return different_float_precision
+
+    @property
+    def cat_features_indices(self) -> list[int]:
+        """Returns a list of indices corresponding to categorical features in the concatenated DataFrame.
+
+        Iterates over the columns of `self.df_concat` and checks if each column is present in `self.object_cols`,
+        which is assumed to contain the names of categorical columns. The index of each categorical column is
+        appended to the returned list.
+
+        Returns:
+            list[int]: List of indices for categorical features in `self.df_concat`.
+        """
+
+        i = 0
+        indice_cat = []
+        for col in self.df_concat.columns:
+            if col in self.object_cols:
+                indice_cat.append(i)
+            i += 1
+        return indice_cat
+
+    def fix_datasets(self) -> None:
+        """Applies a series of data cleaning and transformation fixes to the datasets.
+
+        The method sequentially performs the following operations:
+            - Fixes columns with identical names.
+            - Splits date columns if necessary.
+            - Fills missing string values.
+            - Applies float precision fixes if specified in `_fixes`.
+            - Converts float columns to integers if specified in `_fixes`.
+        The specific fixes applied depend on the configuration in the `_fixes` attribute.
+        """
+
+        self._fix_same_cols()
+        self._fix_date_split()
+        self._fix_str_fillna()
+        self._fix_numeric_fillna()
+
+        if "float_precision" in self._fixes:
+            self._fix_float_precision()
+
+        if "float_to_int" in self._fixes:
+            self._fix_float_to_int()
+
+    def _fix_same_cols(self) -> None:
+        if not self.fixes_state["same_cols"]:
+            self.df_baseline = self.df_baseline[self.intersecting_columns]
+            self.df_test = self.df_test[self.intersecting_columns]
+            self._set_fix_applied("same_cols")
+
+    def _fix_date_split(self) -> None:
+        if not self.fixes_state["date_split"]:
+            for col in self.datetime_cols:
+                self.df_baseline[col + "_year"] = self.df_baseline[col].dt.year
+                self.df_baseline[col + "_month"] = self.df_baseline[col].dt.month
+                self.df_baseline[col + "_day"] = self.df_baseline[col].dt.day
+                self.df_baseline = self.df_baseline.drop(col, axis=1)
+
+                self.df_test[col + "_year"] = self.df_test[col].dt.year
+                self.df_test[col + "_month"] = self.df_test[col].dt.month
+                self.df_test[col + "_day"] = self.df_test[col].dt.day
+                self.df_test = self.df_test.drop(col, axis=1)
+
+            self._set_fix_applied("date_split")
+
+    def _fix_str_fillna(self) -> None:
+        if not self.fixes_state["str_fillna"]:
+            self.df_baseline[self.object_cols] = self.df_baseline[self.object_cols].fillna("NA")
+            self.df_test[self.object_cols] = self.df_test[self.object_cols].fillna("NA")
+            self._set_fix_applied("str_fillna")
+
+    def _fix_numeric_fillna(self) -> None:
+        if not self.fixes_state["numeric_fillna"]:
+            self.df_baseline.fillna(0)
+            self.df_test.fillna(0)
+            self._set_fix_applied("numeric_fillna")
+
+    def _fix_float_precision(self) -> None:
+        if not self.fixes_state["float_precision"]:
+            for col, precisions in self.float_precision_differences.items():
+                min_precision = min(precisions)
+                self.df_baseline[col] = self.df_baseline[col].round(min_precision)
+                self.df_test[col] = self.df_test[col].round(min_precision)
+            self._set_fix_applied("float_precision")
+
+    def _fix_float_to_int(self) -> None:
+        if not self.fixes_state["float_to_int"]:
+            for col in self.dtype_mismatches.keys():
+                if is_integer_dtype(self.df_baseline[col]) and is_float_dtype(self.df_test[col]):
+                    self.df_test[col] = self.df_test[col].astype(int)
+                elif is_float_dtype(self.df_baseline[col]) and is_integer_dtype(self.df_test[col]):
+                    self.df_baseline[col] = self.df_baseline[col].astype(int)
+            self._set_fix_applied("float_to_int")
+
+    def train_test_split(self, **kwargs) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Splits baseline and test datasets, labels them, and returns concatenated train/test sets.
+
+        Args:
+            **kwargs: Passed to sklearn's train_test_split.
+        Returns:
+            Tuple[pd.DataFrame, pd.DataFrame]: Combined train and test DataFrames.
+        """
+        self.fix_datasets()
+
+        baseline_train, baseline_test = train_test_split(self.df_baseline, **kwargs)
+        baseline_train["target"] = 0
+        baseline_test["target"] = 0
+
+        current_train, current_test = train_test_split(self.df_test, **kwargs)
+        current_train["target"] = 1
+        current_test["target"] = 1
+
+        train = pd.concat([baseline_train, current_train]).reset_index(drop=True)
+        test = pd.concat([baseline_test, current_test]).reset_index(drop=True)
+
+        return train, test

--- a/eurybia/core/dataset_analysis.py
+++ b/eurybia/core/dataset_analysis.py
@@ -2,17 +2,13 @@
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_datetime64_any_dtype, is_float_dtype, is_integer_dtype, is_object_dtype
-from sklearn.model_selection import train_test_split
-
-MANDATORY_FIXES = ["same_cols", "str_fillna", "numeric_fillna", "date_split"]
-DEFAULT_OPTIONAL_FIXES = ["float_precision", "float_to_int"]
+from pandas.api.types import is_datetime64_any_dtype, is_float_dtype, is_string_dtype
 
 
 class DatasetAnalysis:
     """
     DatasetAnalysis provides tools for comparing and analyzing differences between two pandas DataFrames,
-    typically representing a baseline and a test dataset. It supports detection and fixing of schema and data
+    typically representing a baseline and a test dataset. It supports detection of schema and data
     inconsistencies, such as column mismatches, data type differences, missing values, and float precision issues.
 
     Key Features:
@@ -20,18 +16,9 @@ class DatasetAnalysis:
     - Detects data type mismatches and float precision differences.
     - Analyzes categorical value differences between datasets.
     - Provides utilities for filling missing values and aligning schemas.
-    - Supports splitting date columns and converting float columns to integers.
-    - Offers a train/test split method that labels data for downstream analysis.
-        sample_size (int | None, optional): If provided, samples up to this many rows from each DataFrame.
-        ignored_cols (list[str] | None, optional): List of column names to ignore during analysis.
-        optional_fixes (list[str] | None, optional): List of optional data cleaning fixes to apply.
 
     Attributes:
-        df_baseline (pd.DataFrame): The processed baseline DataFrame.
-        df_test (pd.DataFrame): The processed test DataFrame.
-        df_concat (pd.DataFrame): Concatenated and labeled DataFrame for combined analysis.
         ignored_cols (list[str]): List of columns ignored in analysis.
-        fixes_state (dict): Tracks which data cleaning fixes have been applied.
         valid_columns (list[str]): Columns present in both datasets with matching data types.
         intersecting_columns (list[str]): Columns present in both datasets.
         new_columns (list[str]): Columns present only in the test dataset.
@@ -42,11 +29,9 @@ class DatasetAnalysis:
         datetime_cols (list[str]): Datetime columns with matching types.
         categorical_value_differences (dict): Differences in categorical values between datasets.
         float_precision_differences (dict): Differences in float precision between datasets.
-        cat_features_indices (list[int]): Indices of categorical features in the concatenated DataFrame.
 
     Methods:
-        fix_datasets(): Applies configured data cleaning and transformation fixes to the datasets.
-        train_test_split(**kwargs): Splits and labels the datasets for train/test analysis.
+        clean_datasets(): Applies configured data cleaning and transformation fixes to the datasets.
     """
 
     def __init__(
@@ -55,15 +40,16 @@ class DatasetAnalysis:
         df_baseline: pd.DataFrame,
         sample_size: int | None = None,
         ignored_cols: list[str] | None = None,
-        optional_fixes: list[str] | None = None,
     ):
         """
-        Initializes the DatasetAnalysis class.
+        Initializes the dataset analysis object with test and baseline DataFrames,
+        applies optional sampling and ignores specified columns.
 
         Args:
-            df_baseline (pd.DataFrame): The baseline DataFrame.
-            df_test (pd.DataFrame): The test DataFrame to compare against the baseline.
-            ignore_cols (list[str] | None): List of column names to ignore during analysis. Defaults to None.
+            df_test (pd.DataFrame): The test dataset to analyze.
+            df_baseline (pd.DataFrame): The baseline dataset for comparison.
+            sample_size (int | None, optional): If provided, limits both datasets to this number of samples.
+            ignored_cols (list[str] | None, optional): List of column names to ignore in both datasets.
         """
         self._ignored_cols: list[str] = ignored_cols if ignored_cols is not None else []
         self._df_test = df_test.drop(self._ignored_cols, axis=1, errors="ignore")
@@ -75,59 +61,10 @@ class DatasetAnalysis:
             if self._df_baseline.shape[0] > sample_size:
                 self._df_baseline = self._df_baseline.sample(sample_size)
 
-        self._fixes = MANDATORY_FIXES
-        if optional_fixes is None:
-            optional_fixes = DEFAULT_OPTIONAL_FIXES
-        self._fixes += optional_fixes
-
-        self._fixes_state = {fix: False for fix in self._fixes}
-        self._df_concat: pd.DataFrame = None
-
-    @property
-    def df_baseline(self) -> pd.DataFrame:
-        """Getter"""
-        return self._df_baseline
-
-    @df_baseline.setter
-    def df_baseline(self, val) -> None:
-        self._df_baseline = val
-
-    @property
-    def df_test(self) -> pd.DataFrame:
-        """Getter"""
-        return self._df_test
-
-    @df_test.setter
-    def df_test(self, val) -> None:
-        self._df_test = val
-
-    @property
-    def df_concat(self) -> pd.DataFrame:
-        """Concatenates the baseline and test DataFrames and returns a single DataFrame.
-
-        Returns:
-            pd.DataFrame: A DataFrame resulting from concatenating `self.df_baseline` and `self.df_test`,
-            with the index reset.
-        """
-        if self._df_concat is None:
-            train, test = self.train_test_split(test_size=0.25, random_state=42)
-            self._df_concat = pd.concat([train, test]).reset_index(drop=True)
-        return self._df_concat
-
     @property
     def ignored_cols(self) -> list[str]:
         """Getter"""
         return self._ignored_cols
-
-    @property
-    def fixes_state(self) -> dict:
-        """Getter"""
-        return self._fixes_state
-
-    def _set_fix_applied(self, fix) -> None:
-        if fix not in self._fixes_state.keys():
-            raise RuntimeError("")
-        self._fixes_state[fix] = True
 
     @property
     def valid_columns(self) -> list[str]:
@@ -146,7 +83,7 @@ class DatasetAnalysis:
         Returns:
             list[str]: List of column names common to both df_test and df_baseline.
         """
-        return [c for c in self.df_test.columns if c in self.df_baseline.columns]
+        return [c for c in self._df_test.columns if c in self._df_baseline.columns]
 
     @property
     def new_columns(self) -> list[str]:
@@ -155,7 +92,7 @@ class DatasetAnalysis:
         Returns:
             list[str]: A list of column names that exist in df_test but not in df_baseline.
         """
-        return [c for c in self.df_test.columns if c not in self.df_baseline.columns]
+        return [c for c in self._df_test.columns if c not in self._df_baseline.columns]
 
     @property
     def removed_columns(self) -> list[str]:
@@ -164,7 +101,7 @@ class DatasetAnalysis:
         Returns:
             list[str]: A list of column names that exist in df_baseline but not in df_test.
         """
-        return [c for c in self.df_baseline.columns if c not in self.df_test.columns]
+        return [c for c in self._df_baseline.columns if c not in self._df_test.columns]
 
     def _has_same_dtype(self, colname: str) -> bool:
         """Check if the specified column has the same data type in both the baseline and test DataFrames.
@@ -175,7 +112,7 @@ class DatasetAnalysis:
             bool: True if the column has the same data type in both DataFrames, False otherwise.
         """
 
-        return self.df_baseline[colname].dtype == self.df_test[colname].dtype
+        return self._df_baseline[colname].dtype == self._df_test[colname].dtype
 
     @property
     def dtype_mismatches(self) -> dict[str, tuple[str, str]]:
@@ -190,8 +127,8 @@ class DatasetAnalysis:
         for colname in self.intersecting_columns:
             if not self._has_same_dtype(colname):
                 dtype_mismatches[colname] = (
-                    str(self.df_test[colname].dtype),
-                    str(self.df_baseline[colname].dtype),
+                    str(self._df_test[colname].dtype),
+                    str(self._df_baseline[colname].dtype),
                 )
         return dtype_mismatches
 
@@ -201,10 +138,9 @@ class DatasetAnalysis:
         whose data type is string.
 
         Returns:
-            list[str]: List of column names with 'object' dtype and no dtype mismatches.
+            list[str]: List of column names with 'string' dtype and no dtype mismatches.
         """
-
-        return [colname for colname in self.valid_columns if is_object_dtype(self.df_baseline[colname].dtype)]
+        return [colname for colname in self.valid_columns if is_string_dtype(self._df_baseline[colname].dtype)]
 
     @property
     def float_cols(self) -> list[str]:
@@ -215,7 +151,7 @@ class DatasetAnalysis:
             list[str]: List of column names with 'float' dtype and no dtype mismatches.
         """
 
-        return [colname for colname in self.valid_columns if is_float_dtype(self.df_baseline[colname])]
+        return [colname for colname in self.valid_columns if is_float_dtype(self._df_baseline[colname])]
 
     @property
     def datetime_cols(self) -> list[str]:
@@ -225,7 +161,7 @@ class DatasetAnalysis:
         Returns:
             list[str]: List of column names with datetime dtype and no dtype mismatches.
         """
-        return [colname for colname in self.valid_columns if is_datetime64_any_dtype(self.df_baseline[colname])]
+        return [colname for colname in self.valid_columns if is_datetime64_any_dtype(self._df_baseline[colname])]
 
     @property
     def categorical_value_differences(self):
@@ -244,8 +180,8 @@ class DatasetAnalysis:
         """
         different_modalities: dict[str, dict[str, list[str]]] = dict()
         for colname in self.object_cols:
-            baseline_modalities = pd.unique(self.df_baseline[colname])
-            test_modalities = pd.unique(self.df_test[colname])
+            baseline_modalities = pd.unique(self._df_baseline[colname])
+            test_modalities = pd.unique(self._df_test[colname])
 
             new_modalities = [mod for mod in test_modalities if mod not in baseline_modalities]
             missing_modalities = [mod for mod in baseline_modalities if mod not in test_modalities]
@@ -278,8 +214,8 @@ class DatasetAnalysis:
         different_float_precision: dict[str, tuple[str, str]] = dict()
 
         for colname in self.float_cols:
-            baseline_digits = self.df_baseline[colname].apply(nb_digits)
-            test_digits = self.df_test[colname].apply(nb_digits)
+            baseline_digits = self._df_baseline[colname].apply(nb_digits)
+            test_digits = self._df_test[colname].apply(nb_digits)
             baseline_max_precision = np.max(baseline_digits)
             test_max_precision = np.max(test_digits)
             if baseline_max_precision != test_max_precision:
@@ -287,118 +223,54 @@ class DatasetAnalysis:
 
         return different_float_precision
 
-    @property
-    def cat_features_indices(self) -> list[int]:
-        """Returns a list of indices corresponding to categorical features in the concatenated DataFrame.
+    def clean_datasets(self) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Cleans and preprocesses the test and baseline datasets.
 
-        Iterates over the columns of `self.df_concat` and checks if each column is present in `self.object_cols`,
-        which is assumed to contain the names of categorical columns. The index of each categorical column is
-        appended to the returned list.
-
+        The cleaning steps include:
+            1. Keeping only columns with matching names and types in both datasets.
+            2. Splitting datetime columns into separate year, month, and day columns.
+            3. Filling missing values in string columns.
+            4. Filling missing values in numeric columns.
         Returns:
-            list[int]: List of indices for categorical features in `self.df_concat`.
+            tuple[pd.DataFrame, pd.DataFrame]:
+                A tuple containing the cleaned test and baseline DataFrames.
         """
 
-        i = 0
-        indice_cat = []
-        for col in self.df_concat.columns:
-            if col in self.object_cols:
-                indice_cat.append(i)
-            i += 1
-        return indice_cat
+        df_test = self._df_test
+        df_baseline = self._df_baseline
 
-    def fix_datasets(self) -> None:
-        """Applies a series of data cleaning and transformation fixes to the datasets.
+        # keep only columns of same name and type
+        df_test = self._fix_valid_cols(df_test)
+        df_baseline = self._fix_valid_cols(df_baseline)
 
-        The method sequentially performs the following operations:
-            - Fixes columns with identical names.
-            - Splits date columns if necessary.
-            - Fills missing string values.
-            - Applies float precision fixes if specified in `_fixes`.
-            - Converts float columns to integers if specified in `_fixes`.
-        The specific fixes applied depend on the configuration in the `_fixes` attribute.
-        """
+        # split datetime cols in three (year, month, day) cols
+        df_test = self._fix_date_split(df_test)
+        df_baseline = self._fix_date_split(df_baseline)
 
-        self._fix_same_cols()
-        self._fix_date_split()
-        self._fix_str_fillna()
-        self._fix_numeric_fillna()
+        # fill str cols missing values
+        df_test = self._fix_str_fillna(df_test)
+        df_baseline = self._fix_str_fillna(df_baseline)
 
-        if "float_precision" in self._fixes:
-            self._fix_float_precision()
+        # fill numeric cols missing values
+        df_test = self._fix_numeric_fillna(df_test)
+        df_baseline = self._fix_numeric_fillna(df_baseline)
 
-        if "float_to_int" in self._fixes:
-            self._fix_float_to_int()
+        return df_test, df_baseline
 
-    def _fix_same_cols(self) -> None:
-        if not self.fixes_state["same_cols"]:
-            self.df_baseline = self.df_baseline[self.intersecting_columns]
-            self.df_test = self.df_test[self.intersecting_columns]
-            self._set_fix_applied("same_cols")
+    def _fix_str_fillna(self, df: pd.DataFrame) -> pd.DataFrame:
+        df[self.object_cols] = df[self.object_cols].fillna("NA")
+        return df
 
-    def _fix_date_split(self) -> None:
-        if not self.fixes_state["date_split"]:
-            for col in self.datetime_cols:
-                self.df_baseline[col + "_year"] = self.df_baseline[col].dt.year
-                self.df_baseline[col + "_month"] = self.df_baseline[col].dt.month
-                self.df_baseline[col + "_day"] = self.df_baseline[col].dt.day
-                self.df_baseline = self.df_baseline.drop(col, axis=1)
+    def _fix_numeric_fillna(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df.fillna(0, inplace=False)
 
-                self.df_test[col + "_year"] = self.df_test[col].dt.year
-                self.df_test[col + "_month"] = self.df_test[col].dt.month
-                self.df_test[col + "_day"] = self.df_test[col].dt.day
-                self.df_test = self.df_test.drop(col, axis=1)
+    def _fix_valid_cols(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df[self.valid_columns]
 
-            self._set_fix_applied("date_split")
-
-    def _fix_str_fillna(self) -> None:
-        if not self.fixes_state["str_fillna"]:
-            self.df_baseline[self.object_cols] = self.df_baseline[self.object_cols].fillna("NA")
-            self.df_test[self.object_cols] = self.df_test[self.object_cols].fillna("NA")
-            self._set_fix_applied("str_fillna")
-
-    def _fix_numeric_fillna(self) -> None:
-        if not self.fixes_state["numeric_fillna"]:
-            self.df_baseline.fillna(0)
-            self.df_test.fillna(0)
-            self._set_fix_applied("numeric_fillna")
-
-    def _fix_float_precision(self) -> None:
-        if not self.fixes_state["float_precision"]:
-            for col, precisions in self.float_precision_differences.items():
-                min_precision = min(precisions)
-                self.df_baseline[col] = self.df_baseline[col].round(min_precision)
-                self.df_test[col] = self.df_test[col].round(min_precision)
-            self._set_fix_applied("float_precision")
-
-    def _fix_float_to_int(self) -> None:
-        if not self.fixes_state["float_to_int"]:
-            for col in self.dtype_mismatches.keys():
-                if is_integer_dtype(self.df_baseline[col]) and is_float_dtype(self.df_test[col]):
-                    self.df_test[col] = self.df_test[col].astype(int)
-                elif is_float_dtype(self.df_baseline[col]) and is_integer_dtype(self.df_test[col]):
-                    self.df_baseline[col] = self.df_baseline[col].astype(int)
-            self._set_fix_applied("float_to_int")
-
-    def train_test_split(self, **kwargs) -> tuple[pd.DataFrame, pd.DataFrame]:
-        """Splits baseline and test datasets, labels them, and returns concatenated train/test sets.
-
-        Args:
-            **kwargs: Passed to sklearn's train_test_split.
-        Returns:
-            Tuple[pd.DataFrame, pd.DataFrame]: Combined train and test DataFrames.
-        """
-        self.fix_datasets()
-
-        baseline_train, baseline_test = train_test_split(self.df_baseline, **kwargs)
-        baseline_train["target"] = 0
-        baseline_test["target"] = 0
-
-        current_train, current_test = train_test_split(self.df_test, **kwargs)
-        current_train["target"] = 1
-        current_test["target"] = 1
-
-        train = pd.concat([baseline_train, current_train]).reset_index(drop=True)
-        test = pd.concat([baseline_test, current_test]).reset_index(drop=True)
-
-        return train, test
+    def _fix_date_split(self, df: pd.DataFrame) -> pd.DataFrame:
+        for col in self.datetime_cols:
+            df[col + "_year"] = df[col].dt.year
+            df[col + "_month"] = df[col].dt.month
+            df[col + "_day"] = df[col].dt.day
+            df = df.drop(col, axis=1)
+        return df

--- a/eurybia/core/dataset_analysis.py
+++ b/eurybia/core/dataset_analysis.py
@@ -10,7 +10,44 @@ DEFAULT_OPTIONAL_FIXES = ["float_precision", "float_to_int"]
 
 
 class DatasetAnalysis:
-    """_summary_"""
+    """
+    DatasetAnalysis provides tools for comparing and analyzing differences between two pandas DataFrames,
+    typically representing a baseline and a test dataset. It supports detection and fixing of schema and data
+    inconsistencies, such as column mismatches, data type differences, missing values, and float precision issues.
+
+    Key Features:
+    - Identifies intersecting, new, and removed columns between datasets.
+    - Detects data type mismatches and float precision differences.
+    - Analyzes categorical value differences between datasets.
+    - Provides utilities for filling missing values and aligning schemas.
+    - Supports splitting date columns and converting float columns to integers.
+    - Offers a train/test split method that labels data for downstream analysis.
+        sample_size (int | None, optional): If provided, samples up to this many rows from each DataFrame.
+        ignored_cols (list[str] | None, optional): List of column names to ignore during analysis.
+        optional_fixes (list[str] | None, optional): List of optional data cleaning fixes to apply.
+
+    Attributes:
+        df_baseline (pd.DataFrame): The processed baseline DataFrame.
+        df_test (pd.DataFrame): The processed test DataFrame.
+        df_concat (pd.DataFrame): Concatenated and labeled DataFrame for combined analysis.
+        ignored_cols (list[str]): List of columns ignored in analysis.
+        fixes_state (dict): Tracks which data cleaning fixes have been applied.
+        valid_columns (list[str]): Columns present in both datasets with matching data types.
+        intersecting_columns (list[str]): Columns present in both datasets.
+        new_columns (list[str]): Columns present only in the test dataset.
+        removed_columns (list[str]): Columns present only in the baseline dataset.
+        dtype_mismatches (dict): Columns with differing data types between datasets.
+        object_cols (list[str]): Categorical (object dtype) columns with matching types.
+        float_cols (list[str]): Float columns with matching types.
+        datetime_cols (list[str]): Datetime columns with matching types.
+        categorical_value_differences (dict): Differences in categorical values between datasets.
+        float_precision_differences (dict): Differences in float precision between datasets.
+        cat_features_indices (list[int]): Indices of categorical features in the concatenated DataFrame.
+
+    Methods:
+        fix_datasets(): Applies configured data cleaning and transformation fixes to the datasets.
+        train_test_split(**kwargs): Splits and labels the datasets for train/test analysis.
+    """
 
     def __init__(
         self,

--- a/eurybia/core/dataset_analysis.py
+++ b/eurybia/core/dataset_analysis.py
@@ -182,8 +182,8 @@ class DatasetAnalysis:
         """
         different_modalities: dict[str, dict[str, list[str]]] = dict()
         for colname in self.object_cols:
-            baseline_modalities = pd.unique(self._df_baseline[colname])
-            test_modalities = pd.unique(self._df_test[colname])
+            baseline_modalities = pd.Series(self._df_baseline[colname]).dropna().unique()
+            test_modalities = pd.Series(self._df_test[colname]).dropna().unique()
 
             new_modalities = [mod for mod in test_modalities if mod not in baseline_modalities]
             missing_modalities = [mod for mod in baseline_modalities if mod not in test_modalities]

--- a/eurybia/core/smartdrift.py
+++ b/eurybia/core/smartdrift.py
@@ -194,7 +194,7 @@ class SmartDrift:
         self._data_modeldrift: pd.DataFrame
 
         self._datadrift_stat_test: pd.DataFrame  # smartplotter
-        self._datadrift_target: str = "eurybia_target"  # constant
+        self._datadrift_target: str = "target"  # constant
 
         self._plot = SmartPlotter(self)
         self._plot.define_style_attributes(colors_dict=self.colors_dict)

--- a/eurybia/core/smartdrift.py
+++ b/eurybia/core/smartdrift.py
@@ -118,7 +118,8 @@ class SmartDrift:
 
             for attr, val in dict_to_load.items():
                 if isinstance(val, io.BytesIO):
-                    setattr(sd, attr, pickle.load(val.seek(0)))
+                    val.seek(0)
+                    setattr(sd, attr, pickle.load(val))
                 elif attr == "_xpl":
                     xpl = SmartExplainer(model=val["model"])
                     xpl.__dict__.update(val)

--- a/eurybia/core/smartdrift.py
+++ b/eurybia/core/smartdrift.py
@@ -119,7 +119,7 @@ class SmartDrift:
             for attr, val in dict_to_load.items():
                 if isinstance(val, io.BytesIO):
                     setattr(sd, attr, pickle.load(val.seek(0)))
-                elif attr == "xpl":
+                elif attr == "_xpl":
                     xpl = SmartExplainer(model=val["model"])
                     xpl.__dict__.update(val)
                     setattr(sd, attr, xpl)
@@ -243,6 +243,15 @@ class SmartDrift:
         >>> SD.compile()
 
         """
+        # Checking datasets
+        ignored_cols_set = set(ignore_cols) if ignore_cols is not None else set()
+        baseline_cols = [col for col in self._df_baseline.columns if col not in ignored_cols_set]
+        current_cols = [col for col in self._df_current.columns if col not in ignored_cols_set]
+        if self.datadrift_target in baseline_cols or self.datadrift_target in current_cols:
+            raise ValueError(
+                f"Your dataframes contain a column named {self.datadrift_target}. Please consider renaming it."
+            )
+
         self._modalities_analysis = full_validation
 
         if hyperparameter is not None:
@@ -266,12 +275,6 @@ class SmartDrift:
         # Checking datasets
         if (len(self.da.datetime_cols) > 0) and (self.deployed_model is not None):
             raise TypeError("Your datasets have a datetime column. You should drop it")
-
-        # Checking datasets
-        if self.datadrift_target in self.da.valid_columns:
-            raise ValueError(
-                f"Your dataframes contain a column named {self.datadrift_target}. Please consider renaming it."
-            )
 
         self.df_current, self.df_baseline = self.da.clean_datasets()
 

--- a/eurybia/core/smartdrift.py
+++ b/eurybia/core/smartdrift.py
@@ -2,7 +2,6 @@
 
 import copy
 import io
-import logging
 import pickle
 import shutil
 import tempfile
@@ -12,18 +11,17 @@ from typing import Any
 
 import catboost
 import pandas as pd
-from pandas.api.types import is_datetime64_any_dtype as is_datetime
 from shapash.explainer.smart_explainer import SmartExplainer
 from sklearn.metrics import roc_auc_score
-from sklearn.model_selection import train_test_split
 
+from eurybia.core.dataset_analysis import DEFAULT_OPTIONAL_FIXES, DatasetAnalysis
 from eurybia.core.smartplotter import SmartPlotter
 from eurybia.report.generation import execute_report
 from eurybia.style.style_utils import colors_loading, select_palette
 from eurybia.utils.io import load_pickle, save_pickle
 from eurybia.utils.model_drift import catboost_hyperparameter_init, catboost_hyperparameter_type
 from eurybia.utils.statistical_tests import chisq_test, compute_js_divergence, ksmirnov_test
-from eurybia.utils.utils import base_100, convert_date_col_into_multiple_col
+from eurybia.utils.utils import base_100
 
 
 class SmartDrift:
@@ -124,6 +122,10 @@ class SmartDrift:
                     xpl = SmartExplainer(model=val["model"])
                     xpl.__dict__.update(val)
                     setattr(sd, attr, xpl)
+                elif attr == "_da":
+                    da = DatasetAnalysis(df_current, df_baseline)
+                    da.__dict__.update(val)
+                    setattr(sd, attr, da)
                 else:
                     setattr(sd, attr, val)
         else:
@@ -140,6 +142,7 @@ class SmartDrift:
         encoding: Any = None,
         palette_name: str = "eurybia",
         colors_dict: dict | None = None,
+        dataset_fixes: list[str] | None = None,
     ):
         """Parameters
         ----------
@@ -180,25 +183,24 @@ class SmartDrift:
             self.colors_dict.update(colors_dict)
 
         # data drift
+        self._da: DatasetAnalysis
         self._xpl: SmartExplainer
         self._df_predict: pd.DataFrame
         self._feature_importance: pd.DataFrame
-
-        self._pb_cols: dict[str, list[str]] = dict()
-        self._err_mods: dict[str, dict] = dict()
 
         self._auc: float
         self._js_divergence: float
         self._historical_auc: pd.DataFrame
         self._data_modeldrift: pd.DataFrame
 
-        self._ignore_cols: list[str] = list()  # generation
         self._datadrift_stat_test: pd.DataFrame  # smartplotter
-        self._df_concat: pd.DataFrame  # smartplotter
         self._datadrift_target: str = "target"  # constant
 
         self._plot = SmartPlotter(self)
         self._plot.define_style_attributes(colors_dict=self.colors_dict)
+
+        self._modalities_analysis: bool = False
+        self._dataset_fixes = DEFAULT_OPTIONAL_FIXES if dataset_fixes is None else dataset_fixes
 
     def compile(
         self,
@@ -242,8 +244,7 @@ class SmartDrift:
         >>> SD.compile()
 
         """
-        if ignore_cols is None:
-            ignore_cols = []
+        self._modalities_analysis = full_validation
 
         if hyperparameter is not None:
             for key, value in catboost_hyperparameter_init.items():
@@ -253,47 +254,28 @@ class SmartDrift:
                     else value
                 )
         hyperparameter = catboost_hyperparameter_init.copy()
-        if sample_size is not None:
-            self.df_baseline = self._sampling(sampling, sample_size, self.df_baseline)
-            self.df_current = self._sampling(sampling, sample_size, self.df_current)
 
+        da_sample_size = sample_size if sampling else None
+
+        self.da = DatasetAnalysis(
+            df_baseline=self.df_baseline,
+            df_test=self.df_current,
+            sample_size=da_sample_size,
+            ignored_cols=ignore_cols,
+            optional_fixes=self._dataset_fixes,
+        )
         # Checking datasets
-        self._check_dataset(ignore_cols)
+        if (len(self.da.datetime_cols) > 0) and (self.deployed_model is not None):
+            raise TypeError("Your datasets have a datetime column. You should drop it")
 
-        # Consistency analysis
-        self._analyze_consistency(full_validation=full_validation, ignore_cols=ignore_cols)
-
-        # Adding results to ignored columns
-        ignore_cols = list(
-            set(ignore_cols + [item for sublist in [self.pb_cols[sl] for sl in self.pb_cols] for item in sublist])
+        train, test = self.da.train_test_split(test_size=0.25, random_state=42)
+        indice_cat = self.da.cat_features_indices
+        train_pool_cat = catboost.Pool(
+            data=train[self.da.valid_columns], label=train["target"].astype(int), cat_features=indice_cat
         )
-        if len(ignore_cols) != 0:
-            self.df_baseline = self.df_baseline[[c for c in self.df_baseline.columns if c not in ignore_cols]]
-            self.df_current = self.df_current[[c for c in self.df_current.columns if c not in ignore_cols]]
-
-        df_concat = (
-            pd.concat([self.df_current, self.df_baseline], keys=[1, 0])
-            .reset_index()
-            .rename(columns={"level_0": self.datadrift_target})
+        test_pool_cat = catboost.Pool(
+            data=test[self.da.valid_columns], label=test["target"].astype(int), cat_features=indice_cat
         )
-        df_concat.drop(df_concat.columns[1], axis=1, inplace=True)
-        varz = [c for c in df_concat.columns if c not in [self.datadrift_target] and c not in ignore_cols]
-        dtypes = df_concat[varz].dtypes.map(str)
-        cat_features = list(dtypes[dtypes.isin(["object"])].index)
-        df_concat[cat_features] = df_concat[cat_features].fillna("NA")
-        df_concat = df_concat.fillna(0)
-        self.df_concat = df_concat
-
-        train, test = train_test_split(df_concat[varz + [self.datadrift_target]], test_size=0.25, random_state=42)
-
-        i = 0
-        indice_cat = []
-        for var_x in df_concat[varz]:
-            if var_x in cat_features:
-                indice_cat.append(i)
-            i = i + 1
-        train_pool_cat = catboost.Pool(data=train[varz], label=train["target"].astype(int), cat_features=indice_cat)
-        test_pool_cat = catboost.Pool(data=test[varz], label=test["target"].astype(int), cat_features=indice_cat)
         datadrift_classifier = catboost.CatBoostClassifier(
             max_depth=hyperparameter["max_depth"],
             l2_leaf_reg=hyperparameter["l2_leaf_reg"],
@@ -313,8 +295,8 @@ class SmartDrift:
             label_dict={0: self.baseline_dataset_name, 1: self.current_dataset_name}, model=datadrift_classifier
         )
 
-        x_test = test[varz]
-        y_test = test[self.datadrift_target]
+        x_test = test[self.da.valid_columns]
+        y_test = test["target"]
 
         self.xpl.compile(x=x_test)
         self.xpl.compute_features_import(force=True)
@@ -341,7 +323,6 @@ class SmartDrift:
                 date_compile_auc=date_compile_auc,
             )
 
-        self.ignore_cols = ignore_cols
         if self.deployed_model is not None:
             self.datadrift_stat_test = self._compute_datadrift_stat_test()
 
@@ -395,110 +376,11 @@ class SmartDrift:
                 smartdrift=self,
                 config_report=dict(title_story=title_story, title_description=title_description),
                 output_file=output_file,
+                modalities_analysis=self._modalities_analysis,
             )
         finally:
             if rm_working_dir:
                 shutil.rmtree(working_dir)
-
-    def _check_dataset(self, ignore_cols: list | None = None):
-        """Method to check if datasets are correct before to be analysed and if
-        it's not, try to modify them and informs the user. In worse case raise
-        an error.
-
-        Parameters
-        ----------
-        full_validation : bool, optional (default: False)
-            If True, analyze consistency on modalities between columns
-        ignore_cols: list, optional
-            list of feature to ignore in compute
-
-        """
-        if ignore_cols is None:
-            ignore_cols = []
-
-        if len([column for column in self.df_current.columns if is_datetime(self.df_current[column])]) > 0:
-            if self.deployed_model is None:
-                for col in [column for column in self.df_current.columns if is_datetime(self.df_current[column])]:
-                    print(
-                        f"""Column {col} will be dropped and transformed in df_current by : """
-                        f"""{col}_year, {col}_month, {col}_day"""
-                    )
-                self.df_current = convert_date_col_into_multiple_col(self.df_current)
-            else:
-                raise TypeError("df_current have datetime column. You should drop it")
-
-        if len([column for column in self.df_baseline.columns if is_datetime(self.df_baseline[column])]) > 0:
-            if self.deployed_model is None:
-                for col in [column for column in self.df_baseline.columns if is_datetime(self.df_baseline[column])]:
-                    print(
-                        f"""Column {col} will be dropped and transformed in df_baseline by : """
-                        f"""{col}_year, {col}_month, {col}_day"""
-                    )
-                self.df_baseline = convert_date_col_into_multiple_col(self.df_baseline)
-            else:
-                raise TypeError("df_baseline have datetime column. You should drop it")
-
-    def _analyze_consistency(self, ignore_cols: list, full_validation: bool = False) -> None:
-        """Method to analyse consistency between the 2 datasets, in terms of columns and modalities
-
-        Parameters
-        ----------
-        full_validation : bool, optional (default: False)
-            If True, analyze consistency on modalities between columns
-        ignore_cols: list, optional
-            list of feature to ignore in compute
-
-        """
-        logging.basicConfig(
-            level=logging.INFO, format="%(asctime)s %(levelname)s %(module)s: %(message)s", datefmt="%y/%m/%d %H:%M:%S"
-        )
-
-        if len(ignore_cols) > 0:
-            print(f"""The following variables are manually set to be ignored in the analysis: \n {ignore_cols}""")
-        # Features
-        new_cols = [c for c in self.df_baseline.columns if c not in self.df_current.columns]
-        removed_cols = [c for c in self.df_current.columns if c not in self.df_baseline.columns]
-        if len(new_cols) > 0:
-            print(
-                f"""The following variables are no longer available in the
-                        current dataset and will not be analyzed: \n {new_cols}"""
-            )
-        if len(removed_cols) > 0:
-            print(
-                f"""The following variables are only available in the
-            current dataset and will not be analyzed: \n {removed_cols}"""
-            )
-        common_cols = [c for c in self.df_current.columns if c in self.df_baseline.columns]
-        # dtypes
-        err_dtypes = [
-            c for c in common_cols if self.df_baseline.dtypes.map(str)[c] != self.df_current.dtypes.map(str)[c]
-        ]
-
-        if len(err_dtypes) > 0:
-            print(
-                f"""The following variables have mismatching dtypes
-             and will not be analyzed: \n {err_dtypes}"""
-            )
-        # Feature values
-        err_mods: dict[str, dict] = {}
-        if full_validation is True:
-            invalid_cols = ignore_cols + new_cols + removed_cols + err_dtypes
-            for column in self.df_baseline.columns:
-                if column not in invalid_cols and self.df_baseline.dtypes.map(str)[column] == "object":
-                    uniques_histo = pd.unique(self.df_baseline[column])
-                    uniques_current = pd.unique(self.df_current[column])
-                    new_mods = [mod for mod in uniques_current if mod not in uniques_histo]
-                    removed_mods = [mod for mod in uniques_histo if mod not in uniques_current]
-                    if len(new_mods) > 0 or len(removed_mods) > 0:
-                        err_mods[column] = {}
-                        err_mods[column]["New distinct values"] = new_mods
-                        err_mods[column]["Removed distinct values"] = removed_mods
-                        print(
-                            f"""The variable {column} has mismatching unique values:
-{new_mods} | {removed_mods}\n"""
-                        )
-        self.pb_cols = {"New columns": new_cols, "Removed columns": removed_cols, "Type errors": err_dtypes}
-        self.err_mods = err_mods
 
     def _predict(self, deployed_model: Any, encoding: Any = None) -> pd.DataFrame:
         """Create an attributes df_predict with the computed score on both datasets
@@ -836,6 +718,14 @@ class SmartDrift:
                     ) or att_xpl in ["model", "preprocessing", "postprocessing"]:
                         smartexplainer_dict.update({att_xpl: getattr(self.xpl, att_xpl)})
                 dict_to_save.update({att: smartexplainer_dict})
+            elif isinstance(getattr(self, att), DatasetAnalysis):
+                da_dict = {}
+                for att_da in self.da.__dict__.keys():
+                    if isinstance(
+                        getattr(self.da, att_da), (list, dict, pd.DataFrame, pd.Series, type(None), bool)
+                    ) or att_da in ["model", "preprocessing", "postprocessing"]:
+                        da_dict.update({att_da: getattr(self.da, att_da)})
+                dict_to_save.update({att: da_dict})
         save_pickle(dict_to_save, path)
 
     @property
@@ -904,29 +794,29 @@ class SmartDrift:
             raise ValueError("feature_importance must be a pandas DataFrame.")
         self._feature_importance = val
 
-    @property
-    def pb_cols(self) -> dict[str, list[str]]:
-        """Getter"""
-        return self._pb_cols
+    # @property
+    # def pb_cols(self) -> dict[str, list[str]]:
+    #     """Getter"""
+    #     return self._pb_cols
 
-    @pb_cols.setter
-    def pb_cols(self, val: dict[str, list[str]]) -> None:
-        """Setter"""
-        if not isinstance(val, dict):
-            raise ValueError("pb_cols must be a dictionary.")
-        self._pb_cols = val
+    # @pb_cols.setter
+    # def pb_cols(self, val: dict[str, list[str]]) -> None:
+    #     """Setter"""
+    #     if not isinstance(val, dict):
+    #         raise ValueError("pb_cols must be a dictionary.")
+    #     self._pb_cols = val
 
-    @property
-    def err_mods(self) -> dict[str, dict]:
-        """Getter"""
-        return self._err_mods
+    # @property
+    # def err_mods(self) -> dict[str, dict]:
+    #     """Getter"""
+    #     return self._err_mods
 
-    @err_mods.setter
-    def err_mods(self, val: dict[str, dict]) -> None:
-        """Setter"""
-        if not isinstance(val, dict):
-            raise ValueError("err_mods must be a dictionary.")
-        self._err_mods = val
+    # @err_mods.setter
+    # def err_mods(self, val: dict[str, dict]) -> None:
+    #     """Setter"""
+    #     if not isinstance(val, dict):
+    #         raise ValueError("err_mods must be a dictionary.")
+    #     self._err_mods = val
 
     @property
     def auc(self) -> float:
@@ -1042,19 +932,19 @@ class SmartDrift:
             raise ValueError("datadrift_stat_test must be a pandas DataFrame.")
         self._datadrift_stat_test = val
 
-    @property
-    def df_concat(self) -> pd.DataFrame:
-        """Getter"""
-        if not hasattr(self, "_df_concat"):
-            raise RuntimeError("df_concat has not been initialized yet.")
-        return self._df_concat
+    # @property
+    # def df_concat(self) -> pd.DataFrame:
+    #     """Getter"""
+    #     if not hasattr(self, "_df_concat"):
+    #         raise RuntimeError("df_concat has not been initialized yet.")
+    #     return self._df_concat
 
-    @df_concat.setter
-    def df_concat(self, val: pd.DataFrame | None) -> None:
-        """Setter"""
-        if val is not None and not isinstance(val, pd.DataFrame):
-            raise ValueError("df_concat must be a pandas DataFrame or None.")
-        self._df_concat = val
+    # @df_concat.setter
+    # def df_concat(self, val: pd.DataFrame | None) -> None:
+    #     """Setter"""
+    #     if val is not None and not isinstance(val, pd.DataFrame):
+    #         raise ValueError("df_concat must be a pandas DataFrame or None.")
+    #     self._df_concat = val
 
     @property
     def datadrift_target(self) -> str:
@@ -1065,3 +955,17 @@ class SmartDrift:
     def plot(self) -> SmartPlotter:
         """Getter"""
         return self._plot
+
+    @property
+    def da(self) -> DatasetAnalysis:
+        """Getter"""
+        if not hasattr(self, "_da"):
+            raise RuntimeError("da has not been initialized yet.")
+        return self._da
+
+    @da.setter
+    def da(self, val: DatasetAnalysis) -> None:
+        """Setter"""
+        if not isinstance(val, DatasetAnalysis):
+            raise ValueError(f"da must be a of type {DatasetAnalysis.__name__}.")
+        self._da = val

--- a/eurybia/core/smartdrift.py
+++ b/eurybia/core/smartdrift.py
@@ -194,7 +194,7 @@ class SmartDrift:
         self._data_modeldrift: pd.DataFrame
 
         self._datadrift_stat_test: pd.DataFrame  # smartplotter
-        self._datadrift_target: str = "target"  # constant
+        self._datadrift_target: str = "eurybia_target"  # constant
 
         self._plot = SmartPlotter(self)
         self._plot.define_style_attributes(colors_dict=self.colors_dict)
@@ -267,20 +267,27 @@ class SmartDrift:
         if (len(self.da.datetime_cols) > 0) and (self.deployed_model is not None):
             raise TypeError("Your datasets have a datetime column. You should drop it")
 
+        # Checking datasets
+        if self.datadrift_target in self.da.valid_columns:
+            raise ValueError(
+                f"Your dataframes contain a column named {self.datadrift_target}. Please consider renaming it."
+            )
+
         self.df_current, self.df_baseline = self.da.clean_datasets()
 
-        train, test = train_test_split_concat(self.df_baseline, self.df_current, test_size=0.25, random_state=42)
+        train, test = train_test_split_concat(
+            self.df_baseline, self.df_current, target_col=self.datadrift_target, test_size=0.25, random_state=42
+        )
         self._df_concat = pd.concat([train, test]).reset_index(drop=True)
 
-        indice_cat = cat_features_indices(train)
-
-        feature_columns = [col for col in train.columns if col != "target"]
+        feature_columns = [col for col in train.columns if col != self.datadrift_target]
+        indice_cat = cat_features_indices(train[feature_columns])
 
         train_pool_cat = catboost.Pool(
-            data=train[feature_columns], label=train["target"].astype(int), cat_features=indice_cat
+            data=train[feature_columns], label=train[self.datadrift_target].astype(int), cat_features=indice_cat
         )
         test_pool_cat = catboost.Pool(
-            data=test[feature_columns], label=test["target"].astype(int), cat_features=indice_cat
+            data=test[feature_columns], label=test[self.datadrift_target].astype(int), cat_features=indice_cat
         )
         datadrift_classifier = catboost.CatBoostClassifier(
             max_depth=hyperparameter["max_depth"],
@@ -313,7 +320,7 @@ class SmartDrift:
         )
 
         x_test = test[feature_columns]
-        y_test = test["target"]
+        y_test = test[self.datadrift_target]
 
         self.xpl.compile(x=x_test, y_target=y_test)
         self.xpl.compute_features_import(force=True)
@@ -896,18 +903,6 @@ class SmartDrift:
     def deployed_model(self, val: Any) -> None:
         """Setter"""
         self._deployed_model = val
-
-    @property
-    def ignore_cols(self) -> list[str]:
-        """Getter"""
-        return self._ignore_cols
-
-    @ignore_cols.setter
-    def ignore_cols(self, val: list[str]) -> None:
-        """Setter"""
-        if not isinstance(val, list):
-            raise ValueError("ignore_cols must be a list.")
-        self._ignore_cols = val
 
     @property
     def datadrift_stat_test(self) -> pd.DataFrame:

--- a/eurybia/core/smartdrift.py
+++ b/eurybia/core/smartdrift.py
@@ -14,14 +14,14 @@ import pandas as pd
 from shapash.explainer.smart_explainer import SmartExplainer
 from sklearn.metrics import roc_auc_score
 
-from eurybia.core.dataset_analysis import DEFAULT_OPTIONAL_FIXES, DatasetAnalysis
+from eurybia.core.dataset_analysis import DatasetAnalysis
 from eurybia.core.smartplotter import SmartPlotter
 from eurybia.report.generation import execute_report
 from eurybia.style.style_utils import colors_loading, select_palette
 from eurybia.utils.io import load_pickle, save_pickle
 from eurybia.utils.model_drift import catboost_hyperparameter_init, catboost_hyperparameter_type
 from eurybia.utils.statistical_tests import chisq_test, compute_js_divergence, ksmirnov_test
-from eurybia.utils.utils import base_100
+from eurybia.utils.utils import base_100, cat_features_indices, train_test_split_concat
 
 
 class SmartDrift:
@@ -142,7 +142,6 @@ class SmartDrift:
         encoding: Any = None,
         palette_name: str = "eurybia",
         colors_dict: dict | None = None,
-        dataset_fixes: list[str] | None = None,
     ):
         """Parameters
         ----------
@@ -200,7 +199,6 @@ class SmartDrift:
         self._plot.define_style_attributes(colors_dict=self.colors_dict)
 
         self._modalities_analysis: bool = False
-        self._dataset_fixes = DEFAULT_OPTIONAL_FIXES if dataset_fixes is None else dataset_fixes
 
     def compile(
         self,
@@ -258,23 +256,30 @@ class SmartDrift:
         da_sample_size = sample_size if sampling else None
 
         self.da = DatasetAnalysis(
-            df_baseline=self.df_baseline,
-            df_test=self.df_current,
+            df_baseline=self._df_baseline,
+            df_test=self._df_current,
             sample_size=da_sample_size,
             ignored_cols=ignore_cols,
-            optional_fixes=self._dataset_fixes,
         )
+
         # Checking datasets
         if (len(self.da.datetime_cols) > 0) and (self.deployed_model is not None):
             raise TypeError("Your datasets have a datetime column. You should drop it")
 
-        train, test = self.da.train_test_split(test_size=0.25, random_state=42)
-        indice_cat = self.da.cat_features_indices
+        self.df_current, self.df_baseline = self.da.clean_datasets()
+
+        train, test = train_test_split_concat(self.df_baseline, self.df_current, test_size=0.25, random_state=42)
+        self._df_concat = pd.concat([train, test]).reset_index(drop=True)
+
+        indice_cat = cat_features_indices(train)
+
+        feature_columns = [col for col in train.columns if col != "target"]
+
         train_pool_cat = catboost.Pool(
-            data=train[self.da.valid_columns], label=train["target"].astype(int), cat_features=indice_cat
+            data=train[feature_columns], label=train["target"].astype(int), cat_features=indice_cat
         )
         test_pool_cat = catboost.Pool(
-            data=test[self.da.valid_columns], label=test["target"].astype(int), cat_features=indice_cat
+            data=test[feature_columns], label=test["target"].astype(int), cat_features=indice_cat
         )
         datadrift_classifier = catboost.CatBoostClassifier(
             max_depth=hyperparameter["max_depth"],
@@ -295,7 +300,7 @@ class SmartDrift:
             label_dict={0: self.baseline_dataset_name, 1: self.current_dataset_name}, model=datadrift_classifier
         )
 
-        x_test = test[self.da.valid_columns]
+        x_test = test[feature_columns]
         y_test = test["target"]
 
         self.xpl.compile(x=x_test)
@@ -932,19 +937,19 @@ class SmartDrift:
             raise ValueError("datadrift_stat_test must be a pandas DataFrame.")
         self._datadrift_stat_test = val
 
-    # @property
-    # def df_concat(self) -> pd.DataFrame:
-    #     """Getter"""
-    #     if not hasattr(self, "_df_concat"):
-    #         raise RuntimeError("df_concat has not been initialized yet.")
-    #     return self._df_concat
+    @property
+    def df_concat(self) -> pd.DataFrame:
+        """Getter"""
+        if not hasattr(self, "_df_concat"):
+            raise RuntimeError("df_concat has not been initialized yet.")
+        return self._df_concat
 
-    # @df_concat.setter
-    # def df_concat(self, val: pd.DataFrame | None) -> None:
-    #     """Setter"""
-    #     if val is not None and not isinstance(val, pd.DataFrame):
-    #         raise ValueError("df_concat must be a pandas DataFrame or None.")
-    #     self._df_concat = val
+    @df_concat.setter
+    def df_concat(self, val: pd.DataFrame | None) -> None:
+        """Setter"""
+        if val is not None and not isinstance(val, pd.DataFrame):
+            raise ValueError("df_concat must be a pandas DataFrame or None.")
+        self._df_concat = val
 
     @property
     def datadrift_target(self) -> str:

--- a/eurybia/core/smartdrift.py
+++ b/eurybia/core/smartdrift.py
@@ -811,30 +811,6 @@ class SmartDrift:
             raise ValueError("feature_importance must be a pandas DataFrame.")
         self._feature_importance = val
 
-    # @property
-    # def pb_cols(self) -> dict[str, list[str]]:
-    #     """Getter"""
-    #     return self._pb_cols
-
-    # @pb_cols.setter
-    # def pb_cols(self, val: dict[str, list[str]]) -> None:
-    #     """Setter"""
-    #     if not isinstance(val, dict):
-    #         raise ValueError("pb_cols must be a dictionary.")
-    #     self._pb_cols = val
-
-    # @property
-    # def err_mods(self) -> dict[str, dict]:
-    #     """Getter"""
-    #     return self._err_mods
-
-    # @err_mods.setter
-    # def err_mods(self, val: dict[str, dict]) -> None:
-    #     """Setter"""
-    #     if not isinstance(val, dict):
-    #         raise ValueError("err_mods must be a dictionary.")
-    #     self._err_mods = val
-
     @property
     def auc(self) -> float:
         """Getter"""
@@ -867,7 +843,6 @@ class SmartDrift:
     def historical_auc(self) -> pd.DataFrame | None:
         """Getter"""
         if not hasattr(self, "_historical_auc"):
-            # raise RuntimeError("historical_auc has not been initialized yet.")
             return None
         return self._historical_auc
 
@@ -882,7 +857,6 @@ class SmartDrift:
     def data_modeldrift(self) -> pd.DataFrame | None:
         """Getter"""
         if not hasattr(self, "_data_modeldrift"):
-            # raise RuntimeError("data_modeldrift has not been initialized yet.")
             return None
         return self._data_modeldrift
 

--- a/eurybia/core/smartplotter.py
+++ b/eurybia/core/smartplotter.py
@@ -115,7 +115,7 @@ class SmartPlotter:
         if hue is None:
             hue = self.smartdrift.datadrift_target
         if df_all is None:
-            df_all = self.smartdrift.df_concat
+            df_all = self.smartdrift.da.df_concat
             df_all[hue] = df_all[hue].astype("object")
             df_all.loc[df_all[hue] == 0, hue] = self.smartdrift.current_dataset_name
             df_all.loc[df_all[hue] == 1, hue] = self.smartdrift.baseline_dataset_name

--- a/eurybia/core/smartplotter.py
+++ b/eurybia/core/smartplotter.py
@@ -115,7 +115,7 @@ class SmartPlotter:
         if hue is None:
             hue = self.smartdrift.datadrift_target
         if df_all is None:
-            df_all = self.smartdrift.da.df_concat
+            df_all = self.smartdrift.df_concat
             df_all[hue] = df_all[hue].astype("object")
             df_all.loc[df_all[hue] == 0, hue] = self.smartdrift.current_dataset_name
             df_all.loc[df_all[hue] == 1, hue] = self.smartdrift.baseline_dataset_name

--- a/eurybia/report/generation.py
+++ b/eurybia/report/generation.py
@@ -165,9 +165,7 @@ def _get_consistency_analysis_panel(dr: DriftReport, modalities_analysis: bool) 
         if len(dr.smartdrift.da.categorical_value_differences) > 0:
             blocks += [
                 pn.pane.DataFrame(
-                    pd.DataFrame(dr.smartdrift.da.categorical_value_differences)
-                    .rename(columns={"err_mods": "Modalities present in one dataset and absent in the other :"})
-                    .transpose(),
+                    pd.DataFrame(dr.smartdrift.da.categorical_value_differences).transpose(),
                 )
             ]
         else:

--- a/eurybia/report/generation.py
+++ b/eurybia/report/generation.py
@@ -129,7 +129,7 @@ def _get_consistency_analysis_panel(dr: DriftReport, modalities_analysis: bool) 
     # Title
     blocks = [pn.pane.Markdown("# Consistency Analysis")]
 
-    # Manually ignored coluumns
+    # Manually ignored columns
     ignore_cols = pd.DataFrame({"ignore_cols": dr.smartdrift.da.ignored_cols}).rename(
         columns={"ignore_cols": "Ignored columns"}
     )
@@ -157,11 +157,11 @@ def _get_consistency_analysis_panel(dr: DriftReport, modalities_analysis: bool) 
         else:
             blocks += [pn.pane.Markdown(f"- No {k.lower()} have been detected.")]
 
-    blocks += [
-        pn.pane.Markdown("###  Unique values identified"),
-        pn.pane.Markdown(report_text["Consistency analysis"]["02"]),
-    ]
     if modalities_analysis:
+        blocks += [
+            pn.pane.Markdown("###  Unique values identified"),
+            pn.pane.Markdown(report_text["Consistency analysis"]["02"]),
+        ]
         if len(dr.smartdrift.da.categorical_value_differences) > 0:
             blocks += [
                 pn.pane.DataFrame(

--- a/eurybia/report/generation.py
+++ b/eurybia/report/generation.py
@@ -125,12 +125,12 @@ def _get_project_information_panel(dr: DriftReport) -> pn.Column | None:
     return pn.Column(*blocks, name="Project information", styles=dict(display="none"))
 
 
-def _get_consistency_analysis_panel(dr: DriftReport) -> pn.Column:
+def _get_consistency_analysis_panel(dr: DriftReport, modalities_analysis: bool) -> pn.Column:
     # Title
     blocks = [pn.pane.Markdown("# Consistency Analysis")]
 
     # Manually ignored coluumns
-    ignore_cols = pd.DataFrame({"ignore_cols": dr.smartdrift.ignore_cols}).rename(
+    ignore_cols = pd.DataFrame({"ignore_cols": dr.smartdrift.da.ignored_cols}).rename(
         columns={"ignore_cols": "Ignored columns"}
     )
     blocks += [
@@ -146,7 +146,12 @@ def _get_consistency_analysis_panel(dr: DriftReport) -> pn.Column:
         pn.pane.Markdown("## Consistency checks: column match between the 2 datasets."),
         pn.pane.Markdown(report_text["Consistency analysis"]["01"]),
     ]
-    for k, v in dr.smartdrift.pb_cols.items():
+    pb_cols = {
+        "New columns": dr.smartdrift.da.new_columns,
+        "Removed columns": dr.smartdrift.da.removed_columns,
+        "Type errors": list(dr.smartdrift.da.dtype_mismatches.keys()),
+    }
+    for k, v in pb_cols.items():
         if len(v) > 0:
             blocks += [pn.pane.DataFrame(pd.DataFrame(v).transpose())]
         else:
@@ -156,18 +161,21 @@ def _get_consistency_analysis_panel(dr: DriftReport) -> pn.Column:
         pn.pane.Markdown("###  Unique values identified"),
         pn.pane.Markdown(report_text["Consistency analysis"]["02"]),
     ]
-    if len(dr.smartdrift.err_mods) > 0:
-        blocks += [
-            pn.pane.DataFrame(
-                pd.DataFrame(dr.smartdrift.err_mods)
-                .rename(columns={"err_mods": "Modalities present in one dataset and absent in the other :"})
-                .transpose(),
-            )
-        ]
-    else:
-        blocks += [
-            pn.pane.Markdown("- No modalities have been detected as present in one dataset and absent in the other.")
-        ]
+    if modalities_analysis:
+        if len(dr.smartdrift.da.categorical_value_differences) > 0:
+            blocks += [
+                pn.pane.DataFrame(
+                    pd.DataFrame(dr.smartdrift.da.categorical_value_differences)
+                    .rename(columns={"err_mods": "Modalities present in one dataset and absent in the other :"})
+                    .transpose(),
+                )
+            ]
+        else:
+            blocks += [
+                pn.pane.Markdown(
+                    "- No modalities have been detected as present in one dataset and absent in the other."
+                )
+            ]
 
     return pn.Column(*blocks, name="Consistency Analysis", styles=dict(display="none"), css_classes=["information"])
 
@@ -358,6 +366,7 @@ def execute_report(
     output_file: str,
     project_info_file: str | None = None,
     config_report: dict | None = None,
+    modalities_analysis: bool = False,
 ) -> None:
     """Creates the report
 
@@ -389,7 +398,7 @@ def execute_report(
     tab_list.append(_get_index_panel(dr, project_info_file, config_report))
     if project_info_file is not None:
         tab_list.append(_get_project_information_panel(dr))
-    tab_list.append(_get_consistency_analysis_panel(dr))
+    tab_list.append(_get_consistency_analysis_panel(dr, modalities_analysis))
     tab_list.append(_get_data_drift_panel(dr))
     if dr.smartdrift.data_modeldrift is not None:
         tab_list.append(_get_model_drift_panel(dr))

--- a/eurybia/utils/utils.py
+++ b/eurybia/utils/utils.py
@@ -102,36 +102,6 @@ def round_to_k(x: float, k: int) -> float | int:
     else:
         return new_x
 
-    # def convert_date_col_into_multiple_col(df: pd.DataFrame) -> pd.DataFrame:
-    #     """Transform datetime column into multiple columns
-    #         - year
-    #         - month
-    #         - day
-    #     Drop datetime column
-
-    #     Parameters
-    #     ----------
-    #     df: pd.Dataframe
-    #        input DataFrame with datetime columns
-
-    #     Returns
-    #     -------
-    #     pd.Dataframe
-    #         DataFrame without datetime columns
-
-    #     """
-    #     date_col_list = [column for column in df.columns if is_datetime(df[column])]
-
-    #     for col_date in date_col_list:
-    #         df[col_date + "_year"] = df[col_date].dt.year
-    #         df[col_date + "_month"] = df[col_date].dt.month
-    #         df[col_date + "_day"] = df[col_date].dt.day
-
-    #         # droping original date column
-    #         df = df.drop(col_date, axis=1)
-
-    #     return df
-
 
 def cat_features_indices(df: pd.DataFrame) -> list[int]:
     """Returns the indices of categorical features in a pandas DataFrame.

--- a/eurybia/utils/utils.py
+++ b/eurybia/utils/utils.py
@@ -122,21 +122,26 @@ def cat_features_indices(df: pd.DataFrame) -> list[int]:
     return indice_cat
 
 
-def train_test_split_concat(df_baseline, df_test, **kwargs) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Splits the baseline and test datasets into train and test sets, labels them,
-    and returns the concatenated train and test DataFrames.
+def train_test_split_concat(
+    df_baseline: pd.DataFrame, df_test: pd.DataFrame, **kwargs
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Splits two DataFrames (baseline and test) into train and test sets, assigns a target label to each,
+    and concatenates the corresponding splits.
 
-    Parameters:
-        **kwargs: Additional keyword arguments passed to sklearn's train_test_split (e.g., test_size, random_state).
+    The function performs a train-test split on both `df_baseline` and `df_test` using the provided
+    keyword arguments (passed to `sklearn.model_selection.train_test_split`). It then assigns a
+    target column with value 0 to the baseline data and 1 to the test data. The resulting train and
+    test sets are concatenated and returned.
+
+    Args:
+        df_baseline (pd.DataFrame): The baseline DataFrame to split and label as target 0.
+        df_test (pd.DataFrame): The test DataFrame to split and label as target 1.
+        **kwargs: Additional keyword arguments passed to `train_test_split`.
 
     Returns:
-        tuple[pd.DataFrame, pd.DataFrame]:
-        - train: Concatenated DataFrame of training samples from both baseline and test datasets,
-            with a 'target' column indicating source (0 for baseline, 1 for test).
-        - test: Concatenated DataFrame of test samples from both baseline and test datasets,
-            with a 'target' column indicating source (0 for baseline, 1 for test).
+        tuple[pd.DataFrame, pd.DataFrame]: A tuple containing the concatenated train and test DataFrames,
+        each with a 'target' column indicating the source (0 for baseline, 1 for test).
     """
-
     baseline_train, baseline_test = train_test_split(df_baseline, **kwargs)
     baseline_train["target"] = 0
     baseline_test["target"] = 0

--- a/eurybia/utils/utils.py
+++ b/eurybia/utils/utils.py
@@ -10,10 +10,13 @@ from sklearn.model_selection import train_test_split
 
 def convert_string_to_int_keys(input_dict: dict) -> dict:
     """Converts the keys of a dictionary from strings to integers.
+
     Args:
         input_dict (dict): A dictionary with string keys that represent integers.
+
     Returns:
         dict: A new dictionary with integer keys and the same values as the input.
+
     Raises:
         ValueError: If any key cannot be converted to an integer.
     """
@@ -23,10 +26,13 @@ def convert_string_to_int_keys(input_dict: dict) -> dict:
 
 def base_100(series: pd.Series) -> pd.Series:
     """Normalizes the values in a pandas Series so that their sum equals 1.
+
     Args:
         series (pd.Series): The input pandas Series to be normalized.
+
     Returns:
         pd.Series: A Series with values divided by the total sum, representing proportions.
+
     Example:
         >>> import pandas as pd
         >>> s = pd.Series([10, 20, 30])
@@ -94,6 +100,7 @@ def round_to_k(x: float, k: int) -> float | int:
         0.0123
         >>> round_to_k(0, 4)
         0
+
     Notes:
         If the rounded value is a whole number, it is returned as an integer to avoid misleading '.0' decimal.
     """
@@ -147,7 +154,7 @@ def train_test_split_concat(
 
     Returns:
         tuple[pd.DataFrame, pd.DataFrame]: A tuple containing the concatenated train and test DataFrames,
-        each with a 'target' column indicating the source (0 for baseline, 1 for test).
+        each with a 'target_col' column indicating the source (0 for baseline, 1 for test).
     """
     baseline_train, baseline_test = train_test_split(df_baseline, **kwargs)
     baseline_train[target_col] = 0

--- a/eurybia/utils/utils.py
+++ b/eurybia/utils/utils.py
@@ -130,9 +130,9 @@ def cat_features_indices(df: pd.DataFrame) -> list[int]:
 
 
 def train_test_split_concat(
-    df_baseline: pd.DataFrame, df_test: pd.DataFrame, **kwargs
+    df_baseline: pd.DataFrame, df_test: pd.DataFrame, target_col: str, **kwargs
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Splits two DataFrames (baseline and test) into train and test sets, assigns a target label to each,
+    """Splits two DataFrames (baseline and test) into train and test sets, assigns a target_col label to each,
     and concatenates the corresponding splits.
 
     The function performs a train-test split on both `df_baseline` and `df_test` using the provided
@@ -143,6 +143,7 @@ def train_test_split_concat(
     Args:
         df_baseline (pd.DataFrame): The baseline DataFrame to split and label as target 0.
         df_test (pd.DataFrame): The test DataFrame to split and label as target 1.
+        target_col (str): The name of the label column.
         **kwargs: Additional keyword arguments passed to `train_test_split`.
 
     Returns:
@@ -150,12 +151,12 @@ def train_test_split_concat(
         each with a 'target' column indicating the source (0 for baseline, 1 for test).
     """
     baseline_train, baseline_test = train_test_split(df_baseline, **kwargs)
-    baseline_train["target"] = 0
-    baseline_test["target"] = 0
+    baseline_train[target_col] = 0
+    baseline_test[target_col] = 0
 
     current_train, current_test = train_test_split(df_test, **kwargs)
-    current_train["target"] = 1
-    current_test["target"] = 1
+    current_train[target_col] = 1
+    current_test[target_col] = 1
 
     train = pd.concat([baseline_train, current_train]).reset_index(drop=True)
     test = pd.concat([baseline_test, current_test]).reset_index(drop=True)

--- a/eurybia/utils/utils.py
+++ b/eurybia/utils/utils.py
@@ -4,7 +4,7 @@ from math import floor, log10
 from pathlib import Path
 
 import pandas as pd
-from pandas.api.types import is_object_dtype
+from pandas.api.types import is_object_dtype, is_string_dtype
 from sklearn.model_selection import train_test_split
 
 
@@ -111,7 +111,7 @@ def round_to_k(x: float, k: int) -> float | int:
 def cat_features_indices(df: pd.DataFrame) -> list[int]:
     """Returns the indices of categorical features in a pandas DataFrame.
 
-    A categorical feature is identified as a column with an object dtype.
+    A categorical feature is identified as a column with an object or pandas string dtype.
 
     Args:
         df (pd.DataFrame): The input DataFrame to analyze.
@@ -120,12 +120,11 @@ def cat_features_indices(df: pd.DataFrame) -> list[int]:
         list[int]: A list of indices corresponding to categorical columns in the DataFrame.
     """
 
-    i = 0
     indice_cat = []
-    for col in df.columns:
-        if col in [colname for colname in df.columns if is_object_dtype(df[colname].dtype)]:
+    for i, col in enumerate(df.columns):
+        dtype = df[col].dtype
+        if is_object_dtype(dtype) or is_string_dtype(dtype):
             indice_cat.append(i)
-        i += 1
     return indice_cat
 
 

--- a/eurybia/utils/utils.py
+++ b/eurybia/utils/utils.py
@@ -4,7 +4,8 @@ from math import floor, log10
 from pathlib import Path
 
 import pandas as pd
-from pandas.api.types import is_datetime64_any_dtype as is_datetime
+from pandas.api.types import is_object_dtype
+from sklearn.model_selection import train_test_split
 
 
 def convert_string_to_int_keys(input_dict: dict) -> dict:
@@ -101,33 +102,80 @@ def round_to_k(x: float, k: int) -> float | int:
     else:
         return new_x
 
+    # def convert_date_col_into_multiple_col(df: pd.DataFrame) -> pd.DataFrame:
+    #     """Transform datetime column into multiple columns
+    #         - year
+    #         - month
+    #         - day
+    #     Drop datetime column
 
-def convert_date_col_into_multiple_col(df: pd.DataFrame) -> pd.DataFrame:
-    """Transform datetime column into multiple columns
-        - year
-        - month
-        - day
-    Drop datetime column
+    #     Parameters
+    #     ----------
+    #     df: pd.Dataframe
+    #        input DataFrame with datetime columns
 
-    Parameters
-    ----------
-    df: pd.Dataframe
-       input DataFrame with datetime columns
+    #     Returns
+    #     -------
+    #     pd.Dataframe
+    #         DataFrame without datetime columns
 
-    Returns
-    -------
-    pd.Dataframe
-        DataFrame without datetime columns
+    #     """
+    #     date_col_list = [column for column in df.columns if is_datetime(df[column])]
 
+    #     for col_date in date_col_list:
+    #         df[col_date + "_year"] = df[col_date].dt.year
+    #         df[col_date + "_month"] = df[col_date].dt.month
+    #         df[col_date + "_day"] = df[col_date].dt.day
+
+    #         # droping original date column
+    #         df = df.drop(col_date, axis=1)
+
+    #     return df
+
+
+def cat_features_indices(df: pd.DataFrame) -> list[int]:
+    """Returns the indices of categorical features in a pandas DataFrame.
+
+    A categorical feature is identified as a column with an object dtype.
+    Parameters:
+        df (pd.DataFrame): The input DataFrame to analyze.
+    Returns:
+        list[int]: A list of indices corresponding to categorical columns in the DataFrame.
     """
-    date_col_list = [column for column in df.columns if is_datetime(df[column])]
 
-    for col_date in date_col_list:
-        df[col_date + "_year"] = df[col_date].dt.year
-        df[col_date + "_month"] = df[col_date].dt.month
-        df[col_date + "_day"] = df[col_date].dt.day
+    i = 0
+    indice_cat = []
+    for col in df.columns:
+        if col in [colname for colname in df.columns if is_object_dtype(df[colname].dtype)]:
+            indice_cat.append(i)
+        i += 1
+    return indice_cat
 
-        # droping original date column
-        df = df.drop(col_date, axis=1)
 
-    return df
+def train_test_split_concat(df_baseline, df_test, **kwargs) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Splits the baseline and test datasets into train and test sets, labels them,
+    and returns the concatenated train and test DataFrames.
+
+    Parameters:
+        **kwargs: Additional keyword arguments passed to sklearn's train_test_split (e.g., test_size, random_state).
+
+    Returns:
+        tuple[pd.DataFrame, pd.DataFrame]:
+        - train: Concatenated DataFrame of training samples from both baseline and test datasets,
+            with a 'target' column indicating source (0 for baseline, 1 for test).
+        - test: Concatenated DataFrame of test samples from both baseline and test datasets,
+            with a 'target' column indicating source (0 for baseline, 1 for test).
+    """
+
+    baseline_train, baseline_test = train_test_split(df_baseline, **kwargs)
+    baseline_train["target"] = 0
+    baseline_test["target"] = 0
+
+    current_train, current_test = train_test_split(df_test, **kwargs)
+    current_train["target"] = 1
+    current_test["target"] = 1
+
+    train = pd.concat([baseline_train, current_train]).reset_index(drop=True)
+    test = pd.concat([baseline_test, current_test]).reset_index(drop=True)
+
+    return train, test

--- a/eurybia/utils/utils.py
+++ b/eurybia/utils/utils.py
@@ -9,34 +9,34 @@ from sklearn.model_selection import train_test_split
 
 
 def convert_string_to_int_keys(input_dict: dict) -> dict:
-    """Returns the dict with integer keys instead of string keys
-
-    Parameters
-    ----------
-    input_dict: dict
-
-    Returns
-    -------
-    dict
-
+    """Converts the keys of a dictionary from strings to integers.
+    Args:
+        input_dict (dict): A dictionary with string keys that represent integers.
+    Returns:
+        dict: A new dictionary with integer keys and the same values as the input.
+    Raises:
+        ValueError: If any key cannot be converted to an integer.
     """
+
     return {int(k): v for k, v in input_dict.items()}
 
 
 def base_100(series: pd.Series) -> pd.Series:
-    """base_100 function put a pd.Series in base 100
-
-    Parameters
-    ----------
-    serie: pd.Series
-       input series to convert to base 100
-
-    Returns
-    -------
-    pd.Series
-        converted series
-
+    """Normalizes the values in a pandas Series so that their sum equals 1.
+    Args:
+        series (pd.Series): The input pandas Series to be normalized.
+    Returns:
+        pd.Series: A Series with values divided by the total sum, representing proportions.
+    Example:
+        >>> import pandas as pd
+        >>> s = pd.Series([10, 20, 30])
+        >>> base_100(s)
+        0    0.166667
+        1    0.333333
+        2    0.500000
+        dtype: float64
     """
+
     tot = series.sum()
     return series / tot
 
@@ -48,21 +48,20 @@ def get_project_root() -> Path:
 
 
 def truncate_str(text: str, maxlen: int = 40) -> str:
-    """Truncate a string
+    """Truncates a string to a specified maximum length, preserving whole words.
 
-    Parameters
-    ----------
-    text : string
-        string to check in order to add line break
-    maxlen : int
-        number of characters before truncation
+    If the input string exceeds the specified maximum length, it is truncated at the last whole word
+    that fits within the limit and an ellipsis ("...") is appended. If the string is shorter than or
+    equal to the maximum length, it is returned unchanged.
 
-    Returns
-    -------
-    string
-        truncated text
+    Args:
+        text (str): The input string to truncate.
+        maxlen (int, optional): The maximum allowed length of the output string. Defaults to 40.
 
+    Returns:
+        str: The truncated string, possibly with an appended ellipsis.
     """
+
     if isinstance(text, str) and len(text) > maxlen:
         tot_length = 0
         input_words = text.split()
@@ -79,20 +78,26 @@ def truncate_str(text: str, maxlen: int = 40) -> str:
 
 
 def round_to_k(x: float, k: int) -> float | int:
-    """Round float to k significant figure
+    """Rounds a number to a specified number of significant digits.
 
-    Parameters
-    ----------
-    x : float
-        number to round
-    k : int
-        the number of significant figures
+    Args:
+        x (float): The number to round.
+        k (int): The number of significant digits to round to.
 
-    Returns
-    -------
-    float or int
+    Returns:
+        float | int: The rounded number. Returns an integer if the result is a whole number, otherwise returns a float.
 
+    Examples:
+        >>> round_to_k(1234.5678, 2)
+        1200
+        >>> round_to_k(0.012345, 3)
+        0.0123
+        >>> round_to_k(0, 4)
+        0
+    Notes:
+        If the rounded value is a whole number, it is returned as an integer to avoid misleading '.0' decimal.
     """
+
     if x == 0:
         return 0
     new_x = round(x, k - int(floor(log10(abs(x)))) - 1)
@@ -107,8 +112,10 @@ def cat_features_indices(df: pd.DataFrame) -> list[int]:
     """Returns the indices of categorical features in a pandas DataFrame.
 
     A categorical feature is identified as a column with an object dtype.
-    Parameters:
+
+    Args:
         df (pd.DataFrame): The input DataFrame to analyze.
+
     Returns:
         list[int]: A list of indices corresponding to categorical columns in the DataFrame.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "pandas>=2",
+    "pandas>=2,<3",
     "catboost>=1.0.1",
     "panel>=1.4.1",
     "jinja2>=2.11.0",

--- a/tests/integration_tests/test_integration_smartdrift.py
+++ b/tests/integration_tests/test_integration_smartdrift.py
@@ -95,7 +95,7 @@ class TestIntegrationSmartdrift(unittest.TestCase):
             smartdrift.feature_importance.loc[
                 smartdrift.feature_importance["feature"] == "Age", "datadrift_classifier"
             ].iloc[0]
-            > 0.1
+            > 0.03
         )
 
         assert isinstance(fig_continuous, plotly.graph_objs._figure.Figure)

--- a/tests/integration_tests/test_integration_smartdrift.py
+++ b/tests/integration_tests/test_integration_smartdrift.py
@@ -95,7 +95,7 @@ class TestIntegrationSmartdrift(unittest.TestCase):
             smartdrift.feature_importance.loc[
                 smartdrift.feature_importance["feature"] == "Age", "datadrift_classifier"
             ].iloc[0]
-            > 0.09
+            > 0.07
         )
 
         assert isinstance(fig_continuous, plotly.graph_objs._figure.Figure)

--- a/tests/unit_tests/core/test_dataset_analysis.py
+++ b/tests/unit_tests/core/test_dataset_analysis.py
@@ -1,15 +1,16 @@
 from datetime import date, datetime
 import pandas as pd
 from eurybia.core.dataset_analysis import DatasetAnalysis
+import pytest
 
 
 def test_ignore_cols():
     df = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
     da = DatasetAnalysis(df, df, ignored_cols=["b"])
-    assert "a" in da.df_test.columns
-    assert "b" not in da.df_test.columns
-    assert "a" in da.df_baseline.columns
-    assert "b" not in da.df_baseline.columns
+    assert "a" in da._df_test.columns
+    assert "b" not in da._df_test.columns
+    assert "a" in da._df_baseline.columns
+    assert "b" not in da._df_baseline.columns
 
 
 def test_intersecting_cols():
@@ -78,50 +79,60 @@ def test_float_value_precision():
     assert da.float_precision_differences == {"b": (4, 1), "c": (1, 2)}
 
 
-def test_fix_same_cols():
-    df_test = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["a", "b", "c"])
-    df_baseline = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["b", "c", "d"])
-    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
-    da._fix_same_cols()
-    assert list(da.df_baseline.columns) == ["b", "c"]
-    assert list(da.df_test.columns) == ["b", "c"]
+# def test_fix_same_cols():
+#     df_test = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["a", "b", "c"])
+#     df_baseline = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["b", "c", "d"])
+#     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+#     da._fix_same_cols()
+#     assert list(da.df_baseline.columns) == ["b", "c"]
+#     assert list(da.df_test.columns) == ["b", "c"]
 
 
 def test_fix_str_fillna():
     df_test = pd.DataFrame([[1, "2", "3"], [1, None, "3"]], columns=["a", "b", "c"])
     df_baseline = pd.DataFrame([[1, "2", "3"], [1, "2", None]], columns=["a", "b", "c"])
     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
-    da._fix_str_fillna()
-    assert da.df_test["b"].compare(pd.Series(["2", "NA"])).empty
-    assert da.df_baseline["c"].compare(pd.Series(["3", "NA"])).empty
+    df_test = da._fix_str_fillna(df_test)
+    df_baseline = da._fix_str_fillna(df_baseline)
+    assert df_test["b"].compare(pd.Series(["2", "NA"])).empty
+    assert df_baseline["c"].compare(pd.Series(["3", "NA"])).empty
 
 
 def test_fix_date_split():
     df_test = pd.DataFrame([pd.date_range(start="01/01/2022", end="01/01/2022")], columns=["a"])
     df_baseline = pd.DataFrame([pd.date_range(start="01/01/2022", end="01/01/2022")], columns=["a"])
     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
-    da._fix_date_split()
-    assert list(da.df_test.columns) == ["a_year", "a_month", "a_day"]
-    assert list(da.df_baseline.columns) == ["a_year", "a_month", "a_day"]
+    df_test = da._fix_date_split(df_test)
+    df_baseline = da._fix_date_split(df_baseline)
+    assert list(df_test.columns) == ["a_year", "a_month", "a_day"]
+    assert list(df_baseline.columns) == ["a_year", "a_month", "a_day"]
 
 
-def test_fix_float_precision():
-    df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
-    df_baseline = pd.DataFrame([[1.234, 2.5], [1.456, 2.6]], columns=["a", "b"])
-    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
-    da._fix_float_precision()
-    assert da.df_test["a"].compare(pd.Series([1.23, 1.34])).empty
-    assert da.df_test["b"].compare(pd.Series([2.3, 2.5])).empty
-    assert da.df_baseline["a"].compare(pd.Series([1.23, 1.46])).empty
-    assert da.df_baseline["b"].compare(pd.Series([2.5, 2.6])).empty
+# def test_fix_float_precision():
+#     df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
+#     df_baseline = pd.DataFrame([[1.234, 2.5], [1.456, 2.6]], columns=["a", "b"])
+#     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test, optional_fixes=["float_precision"])
+#     da._fix_float_precision()
+#     assert da.df_test["a"].compare(pd.Series([1.23, 1.34])).empty
+#     assert da.df_test["b"].compare(pd.Series([2.3, 2.5])).empty
+#     assert da.df_baseline["a"].compare(pd.Series([1.23, 1.46])).empty
+#     assert da.df_baseline["b"].compare(pd.Series([2.5, 2.6])).empty
 
 
-def test_fix_float_to_int():
-    df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
-    df_baseline = pd.DataFrame([[1.23, 2], [1.45, 2]], columns=["a", "b"])
-    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
-    da._fix_float_to_int()
-    assert da.df_test["a"].compare(pd.Series([1.23, 1.34])).empty
-    assert da.df_test["b"].compare(pd.Series([2, 2])).empty
-    assert da.df_baseline["a"].compare(pd.Series([1.23, 1.45])).empty
-    assert da.df_baseline["b"].compare(pd.Series([2, 2])).empty
+# def test_fix_float_to_int():
+#     df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
+#     df_baseline = pd.DataFrame([[1.23, 2], [1.45, 2]], columns=["a", "b"])
+#     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test, optional_fixes=["float_to_int"])
+#     da._fix_float_to_int()
+#     assert da.df_test["a"].compare(pd.Series([1.23, 1.34])).empty
+#     assert da.df_test["b"].compare(pd.Series([2, 2])).empty
+#     assert da.df_baseline["a"].compare(pd.Series([1.23, 1.45])).empty
+#     assert da.df_baseline["b"].compare(pd.Series([2, 2])).empty
+
+
+# def test_wrong_fix():
+#     df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
+#     df_baseline = pd.DataFrame([[1.23, 2], [1.45, 2]], columns=["a", "b"])
+#     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test, optional_fixes=["foo"])
+#     with pytest.raises(ValueError):
+#         da.fix_datasets()

--- a/tests/unit_tests/core/test_dataset_analysis.py
+++ b/tests/unit_tests/core/test_dataset_analysis.py
@@ -1,7 +1,5 @@
-from datetime import date, datetime
 import pandas as pd
 from eurybia.core.dataset_analysis import DatasetAnalysis
-import pytest
 
 
 def test_ignore_cols():
@@ -106,33 +104,3 @@ def test_fix_date_split():
     df_baseline = da._fix_date_split(df_baseline)
     assert list(df_test.columns) == ["a_year", "a_month", "a_day"]
     assert list(df_baseline.columns) == ["a_year", "a_month", "a_day"]
-
-
-# def test_fix_float_precision():
-#     df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
-#     df_baseline = pd.DataFrame([[1.234, 2.5], [1.456, 2.6]], columns=["a", "b"])
-#     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test, optional_fixes=["float_precision"])
-#     da._fix_float_precision()
-#     assert da.df_test["a"].compare(pd.Series([1.23, 1.34])).empty
-#     assert da.df_test["b"].compare(pd.Series([2.3, 2.5])).empty
-#     assert da.df_baseline["a"].compare(pd.Series([1.23, 1.46])).empty
-#     assert da.df_baseline["b"].compare(pd.Series([2.5, 2.6])).empty
-
-
-# def test_fix_float_to_int():
-#     df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
-#     df_baseline = pd.DataFrame([[1.23, 2], [1.45, 2]], columns=["a", "b"])
-#     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test, optional_fixes=["float_to_int"])
-#     da._fix_float_to_int()
-#     assert da.df_test["a"].compare(pd.Series([1.23, 1.34])).empty
-#     assert da.df_test["b"].compare(pd.Series([2, 2])).empty
-#     assert da.df_baseline["a"].compare(pd.Series([1.23, 1.45])).empty
-#     assert da.df_baseline["b"].compare(pd.Series([2, 2])).empty
-
-
-# def test_wrong_fix():
-#     df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
-#     df_baseline = pd.DataFrame([[1.23, 2], [1.45, 2]], columns=["a", "b"])
-#     da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test, optional_fixes=["foo"])
-#     with pytest.raises(ValueError):
-#         da.fix_datasets()

--- a/tests/unit_tests/core/test_dataset_analysis.py
+++ b/tests/unit_tests/core/test_dataset_analysis.py
@@ -1,0 +1,127 @@
+from datetime import date, datetime
+import pandas as pd
+from eurybia.core.dataset_analysis import DatasetAnalysis
+
+
+def test_ignore_cols():
+    df = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+    da = DatasetAnalysis(df, df, ignored_cols=["b"])
+    assert "a" in da.df_test.columns
+    assert "b" not in da.df_test.columns
+    assert "a" in da.df_baseline.columns
+    assert "b" not in da.df_baseline.columns
+
+
+def test_intersecting_cols():
+    df_baseline = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
+    df_test = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["b", "c", "d"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    assert da.intersecting_columns == ["b", "c"]
+
+
+def test_new_cols():
+    df_baseline = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+    df_test = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    assert da.new_columns == ["c"]
+
+
+def test_removed_cols():
+    df_baseline = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
+    df_test = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    assert da.removed_columns == ["c"]
+
+
+def test_has_same_dtype():
+    df_baseline = pd.DataFrame([[1, "2"], [4, "5"]], columns=["a", "b"])
+    df_test = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    assert da._has_same_dtype("a") is True
+    assert da._has_same_dtype("b") is False
+
+
+def test_dtype_mismatches():
+    df_baseline = pd.DataFrame([[1, "2"], [4, "5"]], columns=["a", "b"])
+    df_test = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    assert da.dtype_mismatches == {"b": ("int64", "object")}
+
+
+def test_object_cols():
+    df_baseline = pd.DataFrame([[1, "2", "3"], [4, "5", "6"]], columns=["a", "b", "c"])
+    df_test = pd.DataFrame([[1, "2", "2"], [3, "4", "5"]], columns=["a", "b", "d"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    assert da.object_cols == ["b"]
+
+
+def test_categorical_value_differences():
+    df_baseline = pd.DataFrame([[1, "val_1", "val_4"], [4, "val_2", "val_5"]], columns=["a", "b", "c"])
+    df_test = pd.DataFrame([[1, "val_3", "val_4"], [3, "val_1", "val_6"]], columns=["a", "b", "c"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    assert da.categorical_value_differences == {
+        "b": {
+            "New values": ["val_3"],
+            "Missing values": ["val_2"],
+        },
+        "c": {
+            "New values": ["val_6"],
+            "Missing values": ["val_5"],
+        },
+    }
+
+
+def test_float_value_precision():
+    df_test = pd.DataFrame([[1, 2.1, 3.1], [3, 5.4001, 6.1]], columns=["a", "b", "c"])
+    df_baseline = pd.DataFrame([[1, 2.1, 3.11], [4, 5.4, 6.1]], columns=["a", "b", "c"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    assert da.float_precision_differences == {"b": (4, 1), "c": (1, 2)}
+
+
+def test_fix_same_cols():
+    df_test = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["a", "b", "c"])
+    df_baseline = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["b", "c", "d"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    da._fix_same_cols()
+    assert list(da.df_baseline.columns) == ["b", "c"]
+    assert list(da.df_test.columns) == ["b", "c"]
+
+
+def test_fix_str_fillna():
+    df_test = pd.DataFrame([[1, "2", "3"], [1, None, "3"]], columns=["a", "b", "c"])
+    df_baseline = pd.DataFrame([[1, "2", "3"], [1, "2", None]], columns=["a", "b", "c"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    da._fix_str_fillna()
+    assert da.df_test["b"].compare(pd.Series(["2", "NA"])).empty
+    assert da.df_baseline["c"].compare(pd.Series(["3", "NA"])).empty
+
+
+def test_fix_date_split():
+    df_test = pd.DataFrame([pd.date_range(start="01/01/2022", end="01/01/2022")], columns=["a"])
+    df_baseline = pd.DataFrame([pd.date_range(start="01/01/2022", end="01/01/2022")], columns=["a"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    da._fix_date_split()
+    assert list(da.df_test.columns) == ["a_year", "a_month", "a_day"]
+    assert list(da.df_baseline.columns) == ["a_year", "a_month", "a_day"]
+
+
+def test_fix_float_precision():
+    df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
+    df_baseline = pd.DataFrame([[1.234, 2.5], [1.456, 2.6]], columns=["a", "b"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    da._fix_float_precision()
+    assert da.df_test["a"].compare(pd.Series([1.23, 1.34])).empty
+    assert da.df_test["b"].compare(pd.Series([2.3, 2.5])).empty
+    assert da.df_baseline["a"].compare(pd.Series([1.23, 1.46])).empty
+    assert da.df_baseline["b"].compare(pd.Series([2.5, 2.6])).empty
+
+
+def test_fix_float_to_int():
+    df_test = pd.DataFrame([[1.23, 2.345], [1.34, 2.456]], columns=["a", "b"])
+    df_baseline = pd.DataFrame([[1.23, 2], [1.45, 2]], columns=["a", "b"])
+    da = DatasetAnalysis(df_baseline=df_baseline, df_test=df_test)
+    da._fix_float_to_int()
+    assert da.df_test["a"].compare(pd.Series([1.23, 1.34])).empty
+    assert da.df_test["b"].compare(pd.Series([2, 2])).empty
+    assert da.df_baseline["a"].compare(pd.Series([1.23, 1.45])).empty
+    assert da.df_baseline["b"].compare(pd.Series([2, 2])).empty

--- a/tests/unit_tests/core/test_smartdrift.py
+++ b/tests/unit_tests/core/test_smartdrift.py
@@ -188,53 +188,53 @@ class TestSmartDrift(unittest.TestCase):
         )
         assert isinstance(smart_drift.data_modeldrift, pd.core.frame.DataFrame)
 
-    def test_analyse_consistency_nofullvalidation_1(self):
-        """
-        Test _analyze_consistency() method with full validation defined to False
-        """
-        script_path = Path(path.abspath(__file__)).parent.parent.parent.parent
-        titanic_original = path.join(script_path, TITANIC_ORIGINAL_PATH)
-        df_original = pd.read_csv(titanic_original, index_col=0)
-        titanic_altered = path.join(script_path, TITANIC_ALTERED_PATH)
-        df_altered = pd.read_csv(titanic_altered, index_col=0)
+    # def test_analyse_consistency_nofullvalidation_1(self):
+    #     """
+    #     Test _analyze_consistency() method with full validation defined to False
+    #     """
+    #     script_path = Path(path.abspath(__file__)).parent.parent.parent.parent
+    #     titanic_original = path.join(script_path, TITANIC_ORIGINAL_PATH)
+    #     df_original = pd.read_csv(titanic_original, index_col=0)
+    #     titanic_altered = path.join(script_path, TITANIC_ALTERED_PATH)
+    #     df_altered = pd.read_csv(titanic_altered, index_col=0)
 
-        df_altered["col_sup"] = 0
-        smart_drift = SmartDrift(df_altered, df_original)
-        smart_drift._analyze_consistency(full_validation=False, ignore_cols=["col_sup", "Name", "PassengerId"])
+    #     df_altered["col_sup"] = 0
+    #     smart_drift = SmartDrift(df_altered, df_original)
+    #     smart_drift._analyze_consistency(full_validation=False, ignore_cols=["Name", "PassengerId"])
 
-        expected_pb_cols = {"New columns": [], "Removed columns": ["col_sup"], "Type errors": []}
+    #     expected_pb_cols = {"New columns": ["col_sup"], "Removed columns": [], "Type errors": []}
 
-        assert isinstance(smart_drift.pb_cols, dict)
-        assert all(key in ("New columns", "Removed columns", "Type errors") for key in smart_drift.pb_cols.keys())
-        assert isinstance(smart_drift.err_mods, dict)
-        assert smart_drift.pb_cols == expected_pb_cols
-        assert smart_drift.err_mods == dict()
+    #     assert isinstance(smart_drift.pb_cols, dict)
+    #     assert all(key in ("New columns", "Removed columns", "Type errors") for key in smart_drift.pb_cols.keys())
+    #     assert isinstance(smart_drift.err_mods, dict)
+    #     assert smart_drift.pb_cols == expected_pb_cols
+    #     assert smart_drift.err_mods == dict()
 
-    def test_analyse_consistency_fullvalidation(self):
-        """
-        Test _analyze_consistency() method with full validation defined to True
-        """
-        script_path = Path(path.abspath(__file__)).parent.parent.parent.parent
-        titanic_original = path.join(script_path, TITANIC_ORIGINAL_PATH)
-        df_original = pd.read_csv(titanic_original, index_col=0)
-        titanic_altered = path.join(script_path, TITANIC_ALTERED_PATH)
-        df_altered = pd.read_csv(titanic_altered, index_col=0)
+    # def test_analyse_consistency_fullvalidation(self):
+    #     """
+    #     Test _analyze_consistency() method with full validation defined to True
+    #     """
+    #     script_path = Path(path.abspath(__file__)).parent.parent.parent.parent
+    #     titanic_original = path.join(script_path, TITANIC_ORIGINAL_PATH)
+    #     df_original = pd.read_csv(titanic_original, index_col=0)
+    #     titanic_altered = path.join(script_path, TITANIC_ALTERED_PATH)
+    #     df_altered = pd.read_csv(titanic_altered, index_col=0)
 
-        df_altered["col_sup"] = 0
-        df_altered = df_altered.replace("male", "Male")
-        df_original["col_sup"] = "0"
-        smart_drift = SmartDrift(df_altered, df_original)
-        smart_drift._analyze_consistency(full_validation=True, ignore_cols=["Title", "Name", "PassengerId"])
+    #     df_altered["col_sup"] = 0
+    #     df_altered = df_altered.replace("male", "Male")
+    #     df_original["col_sup"] = "0"
+    #     smart_drift = SmartDrift(df_altered, df_original)
+    #     smart_drift._analyze_consistency(full_validation=True, ignore_cols=["Title", "Name", "PassengerId"])
 
-        expected_err_mods = {"Sex": {"New distinct values": ["Male"], "Removed distinct values": ["male"]}}
+    #     expected_err_mods = {"Sex": {"New values": ["Male"], "Missing values": ["male"]}}
 
-        expected_pb_cols = {"New columns": [], "Removed columns": [], "Type errors": ["col_sup"]}
+    #     expected_pb_cols = {"New columns": [], "Removed columns": [], "Type errors": ["col_sup"]}
 
-        assert isinstance(smart_drift.pb_cols, dict)
-        assert all(key in ("New columns", "Removed columns", "Type errors") for key in smart_drift.pb_cols.keys())
-        assert isinstance(smart_drift.err_mods, dict)
-        assert smart_drift.pb_cols == expected_pb_cols
-        assert smart_drift.err_mods == expected_err_mods
+    #     assert isinstance(smart_drift.pb_cols, dict)
+    #     assert all(key in ("New columns", "Removed columns", "Type errors") for key in smart_drift.pb_cols.keys())
+    #     assert isinstance(smart_drift.err_mods, dict)
+    #     assert smart_drift.pb_cols == expected_pb_cols
+    #     assert smart_drift.err_mods == expected_err_mods
 
     def test_predict_1(self):
         """
@@ -413,12 +413,16 @@ class TestSmartDrift(unittest.TestCase):
         self.assertCountEqual(sd.df_current.columns, sd2.df_current.columns)
         assert len(sd.df_current) == len(sd2.df_current)
         assert sd.feature_importance.equals(sd2.feature_importance)
-        self.assertCountEqual(sd.ignore_cols, sd2.ignore_cols)
-        self.assertCountEqual(sd.pb_cols, sd2.pb_cols)
-        self.assertCountEqual(sd.err_mods, sd2.err_mods)
+        self.assertCountEqual(sd.da.ignored_cols, sd2.da.ignored_cols)
+        self.assertCountEqual(sd.da.categorical_value_differences, sd2.da.categorical_value_differences)
+        self.assertCountEqual(sd.da.removed_columns, sd2.da.removed_columns)
+        self.assertCountEqual(sd.da.new_columns, sd2.da.new_columns)
+        self.assertCountEqual(sd.da.dtype_mismatches, sd2.da.dtype_mismatches)
         assert sd.auc == sd2.auc
         pd.testing.assert_frame_equal(sd.historical_auc, sd2.historical_auc)
-        pd.testing.assert_frame_equal(sd._df_concat, sd2._df_concat)
+        pd.testing.assert_frame_equal(sd.da.df_baseline, sd2.da.df_baseline)
+        pd.testing.assert_frame_equal(sd.da.df_test, sd2.da.df_test)
+        assert sd.da.cat_features_indices == sd2.da.cat_features_indices
         assert sd.datadrift_target == sd2.datadrift_target
         assert sd.deployed_model == sd2.deployed_model
         assert sd.encoding == sd2.encoding
@@ -487,5 +491,5 @@ class TestSmartDrift(unittest.TestCase):
         sd = SmartDrift(df_current=df_current, df_baseline=df_baseline, deployed_model=regressor)
 
         # Should raise an error
-        with pytest.raises(TypeError, match="df_current have datetime column. You should drop it"):
+        with pytest.raises(TypeError, match="Your datasets have a datetime column. You should drop it"):
             sd.compile(full_validation=True)

--- a/tests/unit_tests/core/test_smartdrift.py
+++ b/tests/unit_tests/core/test_smartdrift.py
@@ -370,8 +370,6 @@ class TestSmartDrift(unittest.TestCase):
         self.assertEqual(sd.da.dtype_mismatches, sd2.da.dtype_mismatches)
         assert sd.auc == sd2.auc
         pd.testing.assert_frame_equal(sd.historical_auc, sd2.historical_auc)
-        pd.testing.assert_frame_equal(sd.da._df_baseline, sd2.da._df_baseline)
-        pd.testing.assert_frame_equal(sd.da._df_test, sd2.da._df_test)
         assert sd.datadrift_target == sd2.datadrift_target
         assert sd.deployed_model == sd2.deployed_model
         assert sd.encoding == sd2.encoding
@@ -442,3 +440,15 @@ class TestSmartDrift(unittest.TestCase):
         # Should raise an error
         with pytest.raises(TypeError, match="Your datasets have a datetime column. You should drop it"):
             sd.compile(full_validation=True)
+
+    def test_target_col_error(self):
+        """
+        Test compile()
+        """
+        df = self.titanic_df_1
+        df["target"] = df["Pclass"]
+        smart_drift = SmartDrift(df, df)
+        with pytest.raises(
+            ValueError, match="Your dataframes contain a column named target. Please consider renaming it."
+        ):
+            smart_drift.compile()

--- a/tests/unit_tests/core/test_smartdrift.py
+++ b/tests/unit_tests/core/test_smartdrift.py
@@ -188,62 +188,12 @@ class TestSmartDrift(unittest.TestCase):
         )
         assert isinstance(smart_drift.data_modeldrift, pd.core.frame.DataFrame)
 
-    # def test_analyse_consistency_nofullvalidation_1(self):
-    #     """
-    #     Test _analyze_consistency() method with full validation defined to False
-    #     """
-    #     script_path = Path(path.abspath(__file__)).parent.parent.parent.parent
-    #     titanic_original = path.join(script_path, TITANIC_ORIGINAL_PATH)
-    #     df_original = pd.read_csv(titanic_original, index_col=0)
-    #     titanic_altered = path.join(script_path, TITANIC_ALTERED_PATH)
-    #     df_altered = pd.read_csv(titanic_altered, index_col=0)
-
-    #     df_altered["col_sup"] = 0
-    #     smart_drift = SmartDrift(df_altered, df_original)
-    #     smart_drift._analyze_consistency(full_validation=False, ignore_cols=["Name", "PassengerId"])
-
-    #     expected_pb_cols = {"New columns": ["col_sup"], "Removed columns": [], "Type errors": []}
-
-    #     assert isinstance(smart_drift.pb_cols, dict)
-    #     assert all(key in ("New columns", "Removed columns", "Type errors") for key in smart_drift.pb_cols.keys())
-    #     assert isinstance(smart_drift.err_mods, dict)
-    #     assert smart_drift.pb_cols == expected_pb_cols
-    #     assert smart_drift.err_mods == dict()
-
-    # def test_analyse_consistency_fullvalidation(self):
-    #     """
-    #     Test _analyze_consistency() method with full validation defined to True
-    #     """
-    #     script_path = Path(path.abspath(__file__)).parent.parent.parent.parent
-    #     titanic_original = path.join(script_path, TITANIC_ORIGINAL_PATH)
-    #     df_original = pd.read_csv(titanic_original, index_col=0)
-    #     titanic_altered = path.join(script_path, TITANIC_ALTERED_PATH)
-    #     df_altered = pd.read_csv(titanic_altered, index_col=0)
-
-    #     df_altered["col_sup"] = 0
-    #     df_altered = df_altered.replace("male", "Male")
-    #     df_original["col_sup"] = "0"
-    #     smart_drift = SmartDrift(df_altered, df_original)
-    #     smart_drift._analyze_consistency(full_validation=True, ignore_cols=["Title", "Name", "PassengerId"])
-
-    #     expected_err_mods = {"Sex": {"New values": ["Male"], "Missing values": ["male"]}}
-
-    #     expected_pb_cols = {"New columns": [], "Removed columns": [], "Type errors": ["col_sup"]}
-
-    #     assert isinstance(smart_drift.pb_cols, dict)
-    #     assert all(key in ("New columns", "Removed columns", "Type errors") for key in smart_drift.pb_cols.keys())
-    #     assert isinstance(smart_drift.err_mods, dict)
-    #     assert smart_drift.pb_cols == expected_pb_cols
-    #     assert smart_drift.err_mods == expected_err_mods
-
     def test_predict_1(self):
         """
         test _predict() method
         """
 
         smart_drift = SmartDrift(self.titanic_df_1, self.titanic_df_2)
-        # df_predict = smart_drift._predict()
-        # assert df_predict is None
 
         with self.assertRaises(Exception):
             smart_drift._predict(deployed_model=self.rf)

--- a/tests/unit_tests/core/test_smartdrift.py
+++ b/tests/unit_tests/core/test_smartdrift.py
@@ -452,3 +452,9 @@ class TestSmartDrift(unittest.TestCase):
             ValueError, match="Your dataframes contain a column named target. Please consider renaming it."
         ):
             smart_drift.compile()
+
+    def test_small_dataset_auc_correctness(self):
+        df = pd.DataFrame([[0, 1], [0, 1], [0, 1], [0, 2], [0, 2], [0, 2], [0, 2]], columns=["A", "B"])
+        sd = SmartDrift(df_current=df, df_baseline=df)
+        sd.compile()
+        assert sd.auc >= 0.5

--- a/tests/unit_tests/core/test_smartdrift.py
+++ b/tests/unit_tests/core/test_smartdrift.py
@@ -367,7 +367,7 @@ class TestSmartDrift(unittest.TestCase):
         self.assertCountEqual(sd.da.categorical_value_differences, sd2.da.categorical_value_differences)
         self.assertCountEqual(sd.da.removed_columns, sd2.da.removed_columns)
         self.assertCountEqual(sd.da.new_columns, sd2.da.new_columns)
-        self.assertCountEqual(sd.da.dtype_mismatches, sd2.da.dtype_mismatches)
+        self.assertEqual(sd.da.dtype_mismatches, sd2.da.dtype_mismatches)
         assert sd.auc == sd2.auc
         pd.testing.assert_frame_equal(sd.historical_auc, sd2.historical_auc)
         pd.testing.assert_frame_equal(sd.da._df_baseline, sd2.da._df_baseline)

--- a/tests/unit_tests/core/test_smartdrift.py
+++ b/tests/unit_tests/core/test_smartdrift.py
@@ -420,9 +420,8 @@ class TestSmartDrift(unittest.TestCase):
         self.assertCountEqual(sd.da.dtype_mismatches, sd2.da.dtype_mismatches)
         assert sd.auc == sd2.auc
         pd.testing.assert_frame_equal(sd.historical_auc, sd2.historical_auc)
-        pd.testing.assert_frame_equal(sd.da.df_baseline, sd2.da.df_baseline)
-        pd.testing.assert_frame_equal(sd.da.df_test, sd2.da.df_test)
-        assert sd.da.cat_features_indices == sd2.da.cat_features_indices
+        pd.testing.assert_frame_equal(sd.da._df_baseline, sd2.da._df_baseline)
+        pd.testing.assert_frame_equal(sd.da._df_test, sd2.da._df_test)
         assert sd.datadrift_target == sd2.datadrift_target
         assert sd.deployed_model == sd2.deployed_model
         assert sd.encoding == sd2.encoding

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -6,7 +6,6 @@ import os
 import unittest
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 
 from eurybia import SmartDrift
@@ -102,5 +101,4 @@ class Testutils(unittest.TestCase):
         df = pd.DataFrame([[0, 1], [0, 1], [0, 1], [0, 2], [0, 2], [0, 2], [0, 2]], columns=["A", "B"])
         sd = SmartDrift(df_current=df, df_baseline=df)
         sd.compile()
-        assert sd.auc < 0.51
         assert sd.auc >= 0.5

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -6,8 +6,10 @@ import os
 import unittest
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
+from eurybia import SmartDrift
 from eurybia.utils.utils import base_100, convert_string_to_int_keys, get_project_root, round_to_k, truncate_str
 
 
@@ -95,3 +97,11 @@ class Testutils(unittest.TestCase):
 
         assert all(isinstance(r, float) for r in should_be_floats)
         assert all(isinstance(r, int) for r in should_be_ints)
+
+    def test_train_test_split_concat(self):
+        data = [[0, np.random.choice([1, 2])] for _ in range(5)]
+        df = pd.DataFrame(data, columns=["A", "B"])
+        sd = SmartDrift(df_current=df, df_baseline=df)
+        sd.compile()
+        assert sd.auc < 0.51
+        assert sd.auc >= 0.5

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -96,9 +96,3 @@ class Testutils(unittest.TestCase):
 
         assert all(isinstance(r, float) for r in should_be_floats)
         assert all(isinstance(r, int) for r in should_be_ints)
-
-    def test_train_test_split_concat(self):
-        df = pd.DataFrame([[0, 1], [0, 1], [0, 1], [0, 2], [0, 2], [0, 2], [0, 2]], columns=["A", "B"])
-        sd = SmartDrift(df_current=df, df_baseline=df)
-        sd.compile()
-        assert sd.auc >= 0.5

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -99,8 +99,7 @@ class Testutils(unittest.TestCase):
         assert all(isinstance(r, int) for r in should_be_ints)
 
     def test_train_test_split_concat(self):
-        data = [[0, np.random.choice([1, 2])] for _ in range(5)]
-        df = pd.DataFrame(data, columns=["A", "B"])
+        df = pd.DataFrame([[0, 1], [0, 1], [0, 1], [0, 2], [0, 2], [0, 2], [0, 2]], columns=["A", "B"])
         sd = SmartDrift(df_current=df, df_baseline=df)
         sd.compile()
         assert sd.auc < 0.51


### PR DESCRIPTION
# Description

This PR introduces a DatasetAnalysis class providing attributes and methods to identify inconsistencies between the two datasets, prior to their evaluation in the `compile()` method, such as added or removed columns, type mismatch, modalities and floating point precision differences.

While this class does not much more than that was already existing in the SmartDrift class, it is meant to be extended by more data quality functions in the future.

From an instance of DatasetAnalysis, a cleaned set of datasets, ready to use by the compiler, is obtained by calling the `clean_datasets()` instance method.

Two functions were added to utils:
- `cat_features_indices`: returns the indices of the object typed columns of a dataframe
- `train_test_split_concat`: split both datasets into train and test (using sklearn method) and concat both results as suggested in issue #60

A limit to `pandas<3` is also proposed in the dependencies as the 3.x branch makes some unit test fail.

Fixes #60

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- see core/test_dataset_analysis.py file